### PR TITLE
Remove unnecessary if, stask should not be empty

### DIFF
--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -110,12 +110,11 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
 
         Deque<ActiveSpan> activeSpanStack = getActiveSpanStack(httpServletRequest);
         ActiveSpan activeSpan = activeSpanStack.pop();
-        if (activeSpan != null) {
-            for (HandlerInterceptorSpanDecorator decorator : decorators) {
-                decorator.onAfterCompletion(httpServletRequest, httpServletResponse, handler, ex, activeSpan);
-            }
-            activeSpan.deactivate();
+
+        for (HandlerInterceptorSpanDecorator decorator : decorators) {
+            decorator.onAfterCompletion(httpServletRequest, httpServletResponse, handler, ex, activeSpan);
         }
+        activeSpan.deactivate();
     }
 
     private Deque<ActiveSpan> getActiveSpanStack(HttpServletRequest request) {


### PR DESCRIPTION
Related to https://github.com/opentracing-contrib/java-spring-web/issues/23. At the moment this if is unnecessary, `pop` would throw an exception.