### PR TITLE
Fix 'NoSuchElementException' when attempting to deactivate a span tha…

### DIFF
--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import io.opentracing.ActiveSpan;
 import io.opentracing.References;
+import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 
@@ -53,16 +54,22 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
         this.decorators = new ArrayList<>(decorators);
     }
 
-    static boolean hasSpanStarted(HttpServletRequest httpServletRequest) {
+    /**
+     * This method determines whether the HTTP request is being traced.
+     *
+     * @param httpServletRequest The HTTP request
+     * @return Whether the request is being traced
+     */
+    static boolean isTraced(HttpServletRequest httpServletRequest) {
         // exclude pattern, span is not started in filter
-        return httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) != null;
+        return httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) instanceof SpanContext;
     }
 
     @Override
     public boolean preHandle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler)
             throws Exception {
 
-        if (!hasSpanStarted(httpServletRequest)) {
+        if (!isTraced(httpServletRequest)) {
             return true;
         }
 
@@ -98,7 +105,7 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
             HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler)
             throws Exception {
 
-        if (!hasSpanStarted(httpServletRequest)) {
+        if (!isTraced(httpServletRequest)) {
             return;
         }
 
@@ -117,7 +124,7 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
     public void afterCompletion(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
                                 Object handler, Exception ex) throws Exception {
 
-        if (!hasSpanStarted(httpServletRequest)) {
+        if (!isTraced(httpServletRequest)) {
             return;
         }
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -94,6 +94,11 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
             HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler)
             throws Exception {
 
+        // exclude pattern, span is not started in filter
+        if (httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) == null) {
+            return;
+        }
+
         Deque<ActiveSpan> activeSpanStack = getActiveSpanStack(httpServletRequest);
         ActiveSpan activeSpan = activeSpanStack.pop();
 
@@ -108,6 +113,11 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
     @Override
     public void afterCompletion(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
                                 Object handler, Exception ex) throws Exception {
+
+        // exclude pattern, span is not started in filter
+        if (httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) == null) {
+            return;
+        }
 
         Deque<ActiveSpan> activeSpanStack = getActiveSpanStack(httpServletRequest);
         ActiveSpan activeSpan = activeSpanStack.pop();

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -53,7 +53,7 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
         this.decorators = new ArrayList<>(decorators);
     }
 
-    private boolean hasSpanStarted(HttpServletRequest httpServletRequest) {
+    static boolean hasSpanStarted(HttpServletRequest httpServletRequest) {
         // exclude pattern, span is not started in filter
         return httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) != null;
     }

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -53,12 +53,16 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
         this.decorators = new ArrayList<>(decorators);
     }
 
+    private boolean hasSpanStarted(HttpServletRequest httpServletRequest) {
+        // exclude pattern, span is not started in filter
+        return httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) != null;
+    }
+
     @Override
     public boolean preHandle(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler)
             throws Exception {
 
-        // exclude pattern, span is not started in filter
-        if (httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) == null) {
+        if (!hasSpanStarted(httpServletRequest)) {
             return true;
         }
 
@@ -94,8 +98,7 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
             HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Object handler)
             throws Exception {
 
-        // exclude pattern, span is not started in filter
-        if (httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) == null) {
+        if (!hasSpanStarted(httpServletRequest)) {
             return;
         }
 
@@ -114,8 +117,7 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
     public void afterCompletion(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
                                 Object handler, Exception ex) throws Exception {
 
-        // exclude pattern, span is not started in filter
-        if (httpServletRequest.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT) == null) {
+        if (!hasSpanStarted(httpServletRequest)) {
             return;
         }
 

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
@@ -8,39 +8,32 @@ import javax.servlet.http.HttpServletRequest;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import io.opentracing.SpanContext;
 import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 
 public class TracingHandlerInterceptorTest {
 
     @Test
-    public void testHasSpanStarted() {
+    public void testIsTraced() {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn("");
-        assertTrue(TracingHandlerInterceptor.hasSpanStarted(request));
+        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(Mockito.mock(SpanContext.class));
+        assertTrue(TracingHandlerInterceptor.isTraced(request));
     }
 
     @Test
-    public void testHasSpanNotStarted() {
+    public void testIsNotTraced() {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
-        assertFalse(TracingHandlerInterceptor.hasSpanStarted(request));
+        assertFalse(TracingHandlerInterceptor.isTraced(request));
     }
 
     @Test
-    public void testPreHandleNoSpan() throws Exception {
+    public void testNoSpan() throws Exception {
         HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
 
         TracingHandlerInterceptor interceptor = new TracingHandlerInterceptor(null);
         assertTrue(interceptor.preHandle(request, null, null));
-    }
-
-    @Test
-    public void testAfterCompletionNoSpan() throws Exception {
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
-        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
-
-        TracingHandlerInterceptor interceptor = new TracingHandlerInterceptor(null);
         interceptor.afterCompletion(request, null, null, null);
     }
 

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
@@ -1,0 +1,47 @@
+package io.opentracing.contrib.spring.web.interceptor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import io.opentracing.contrib.web.servlet.filter.TracingFilter;
+
+public class TracingHandlerInterceptorTest {
+
+    @Test
+    public void testHasSpanStarted() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn("");
+        assertTrue(TracingHandlerInterceptor.hasSpanStarted(request));
+    }
+
+    @Test
+    public void testHasSpanNotStarted() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
+        assertFalse(TracingHandlerInterceptor.hasSpanStarted(request));
+    }
+
+    @Test
+    public void testPreHandleNoSpan() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
+
+        TracingHandlerInterceptor interceptor = new TracingHandlerInterceptor(null);
+        assertTrue(interceptor.preHandle(request, null, null));
+    }
+
+    @Test
+    public void testAfterCompletionNoSpan() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        Mockito.when(request.getAttribute(TracingFilter.SERVER_SPAN_CONTEXT)).thenReturn(null);
+
+        TracingHandlerInterceptor interceptor = new TracingHandlerInterceptor(null);
+        interceptor.afterCompletion(request, null, null, null);
+    }
+
+}

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
@@ -34,6 +34,7 @@ public class TracingHandlerInterceptorTest {
 
         TracingHandlerInterceptor interceptor = new TracingHandlerInterceptor(null);
         assertTrue(interceptor.preHandle(request, null, null));
+        interceptor.afterConcurrentHandlingStarted(request, null, null);
         interceptor.afterCompletion(request, null, null, null);
     }
 


### PR DESCRIPTION
…t hasn't been created due to skip pattern

```
java.util.NoSuchElementException: null
        at java.util.ArrayDeque.removeFirst(ArrayDeque.java:280) ~[na:1.8.0_131]
        at java.util.ArrayDeque.pop(ArrayDeque.java:517) ~[na:1.8.0_131]
        at io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor.afterCompletion(TracingHandlerInterceptor.java:113) ~[opentracing-spring-web-0.0.7-SNAPSHOT.jar:na]
        at org.springframework.web.servlet.HandlerExecutionChain.triggerAfterCompletion(HandlerExecutionChain.java:170) ~[spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at org.springframework.web.servlet.DispatcherServlet.processDispatchResult(DispatcherServlet.java:1055) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:980) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:897) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:970) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:861) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:687) [javax.servlet-api-3.1.0.jar:3.1.0]
        at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:846) [spring-webmvc-4.3.6.RELEASE.jar:4.3.6.RELEASE]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) [javax.servlet-api-3.1.0.jar:3.1.0]
```