### PR TITLE
RFC: Enable skip patterns to be injects from independent components

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoSkipPatternConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoSkipPatternConfigurationTest.java
@@ -1,0 +1,80 @@
+package io.opentracing.contrib.spring.web.autoconfig;
+
+import java.util.concurrent.Callable;
+
+import org.awaitility.Awaitility;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
+
+/**
+ * @author Pavol Loffay
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {ServerTracingAutoSkipPatternConfigurationTest.SpringConfiguration.class,
+                ServerTracingAutoSkipPatternConfigurationTest.TestController.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ServerTracingAutoSkipPatternConfigurationTest {
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer(new ThreadLocalActiveSpanSource());
+        }
+        @Bean
+        @Qualifier("opentracing.http.skipPattern")
+        public String testSkipPattern() {
+            return "/hello";
+        }
+    }
+
+    @RestController
+    @RequestMapping("/")
+    public static class TestController {
+        
+        @RequestMapping("/hello")
+        public String hello() {
+            return "hello";
+        }
+    }
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @Test
+    public void testRequestIsNotTraced() {
+        testRestTemplate.getForEntity("/hello", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(0));
+
+        Assert.assertEquals(0, mockTracer.finishedSpans().size());
+    }
+
+    public Callable<Integer> reportedSpansSize() {
+        return new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return mockTracer.finishedSpans().size();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Possible mechanism for making the skip pattern configuration more flexible.

This approach would enable separate instrumentations (and the app itself) to provide patterns that should be skipped, rather than having one place that needs to have the value defined for all situations.

For example, the metrics auto-config (when using prometheus servlet exporter) needs to exclude the `/metrics` (or whatever if defined) endpoint. Similarly, when an app is used in kubernetes or openshift, it may be appropriate to exclude the `/health` endpoint (currently defined as a default, but only relevant when app deployed in container platform).