### PR TITLE
Enable an existing WebTracingConfiguration to be used to initialise a…

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
@@ -25,6 +25,11 @@ public class WebTracingConfiguration {
     public static class Builder {
         private Pattern skipPattern;
 
+        public Builder using(WebTracingConfiguration config) {
+            this.skipPattern = config.skipPattern;
+            return this;
+        }
+
         public Builder withSkipPattern(Pattern pattern) {
             this.skipPattern = pattern;
             return this;

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
@@ -22,6 +22,13 @@ public class WebTracingConfiguration {
         return new Builder();
     }
 
+    /**
+     * This method is provided to enable the {@link WebTracingConfiguration} to be updated during
+     * bean post processing. Once the configuration has been used by other layers, then any changes
+     * will not take affect.
+     *
+     * @return A new builder based on the configuration information available in this configuration
+     */
     public Builder toBuilder() {
         return new Builder(this);
     }
@@ -29,10 +36,10 @@ public class WebTracingConfiguration {
     public static class Builder {
         private Pattern skipPattern;
 
-        public Builder() {
+        Builder() {
         }
 
-        public Builder(WebTracingConfiguration config) {
+        Builder(WebTracingConfiguration config) {
             this.skipPattern = config.skipPattern;
         }
 

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
@@ -22,8 +22,8 @@ public class WebTracingConfiguration {
         return new Builder();
     }
 
-    public static Builder builder(WebTracingConfiguration config) {
-        return new Builder(config);
+    public Builder toBuilder() {
+        return new Builder(this);
     }
 
     public static class Builder {

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfiguration.java
@@ -22,12 +22,18 @@ public class WebTracingConfiguration {
         return new Builder();
     }
 
+    public static Builder builder(WebTracingConfiguration config) {
+        return new Builder(config);
+    }
+
     public static class Builder {
         private Pattern skipPattern;
 
-        public Builder using(WebTracingConfiguration config) {
+        public Builder() {
+        }
+
+        public Builder(WebTracingConfiguration config) {
             this.skipPattern = config.skipPattern;
-            return this;
         }
 
         public Builder withSkipPattern(Pattern pattern) {

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
@@ -1,0 +1,28 @@
+package io.opentracing.contrib.spring.web.autoconfig;
+
+import static org.junit.Assert.*;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class WebTracingConfigurationTest {
+
+    @Test
+    public void testUsing() {
+        Pattern pattern = Pattern.compile("/test");
+        WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern).build();
+        WebTracingConfiguration config2 = WebTracingConfiguration.builder().using(config1).build();
+        assertEquals(pattern.pattern(), config2.getSkipPattern().pattern());
+    }
+
+    @Test
+    public void testUsingReplaceSkip() {
+        Pattern pattern1 = Pattern.compile("/test1");
+        Pattern pattern2 = Pattern.compile("/test2");
+        WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern1).build();
+        WebTracingConfiguration config2 = WebTracingConfiguration.builder().using(config1).withSkipPattern(pattern2).build();
+        assertEquals(pattern2.pattern(), config2.getSkipPattern().pattern());
+    }
+
+}

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
@@ -12,7 +12,7 @@ public class WebTracingConfigurationTest {
     public void testUsing() {
         Pattern pattern = Pattern.compile("/test");
         WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern).build();
-        WebTracingConfiguration config2 = WebTracingConfiguration.builder(config1).build();
+        WebTracingConfiguration config2 = config1.toBuilder().build();
         assertEquals(pattern.pattern(), config2.getSkipPattern().pattern());
     }
 
@@ -21,7 +21,7 @@ public class WebTracingConfigurationTest {
         Pattern pattern1 = Pattern.compile("/test1");
         Pattern pattern2 = Pattern.compile("/test2");
         WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern1).build();
-        WebTracingConfiguration config2 = WebTracingConfiguration.builder(config1).withSkipPattern(pattern2).build();
+        WebTracingConfiguration config2 = config1.toBuilder().withSkipPattern(pattern2).build();
         assertEquals(pattern2.pattern(), config2.getSkipPattern().pattern());
     }
 

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingConfigurationTest.java
@@ -12,7 +12,7 @@ public class WebTracingConfigurationTest {
     public void testUsing() {
         Pattern pattern = Pattern.compile("/test");
         WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern).build();
-        WebTracingConfiguration config2 = WebTracingConfiguration.builder().using(config1).build();
+        WebTracingConfiguration config2 = WebTracingConfiguration.builder(config1).build();
         assertEquals(pattern.pattern(), config2.getSkipPattern().pattern());
     }
 
@@ -21,7 +21,7 @@ public class WebTracingConfigurationTest {
         Pattern pattern1 = Pattern.compile("/test1");
         Pattern pattern2 = Pattern.compile("/test2");
         WebTracingConfiguration config1 = WebTracingConfiguration.builder().withSkipPattern(pattern1).build();
-        WebTracingConfiguration config2 = WebTracingConfiguration.builder().using(config1).withSkipPattern(pattern2).build();
+        WebTracingConfiguration config2 = WebTracingConfiguration.builder(config1).withSkipPattern(pattern2).build();
         assertEquals(pattern2.pattern(), config2.getSkipPattern().pattern());
     }
 


### PR DESCRIPTION
… new builder, used to update/replace the previous values

The BeanPostProcessor approach discussed in #28 works, but there is currently no way to update the skip pattern in the `WebTracingConfiguration`. This PR provides a `using` method on the builder to enable an existing configuration to be used to initialise the config before the other builder methods are used to change the values.

Its not an issue currently, as the `WebTracingConfiguration` only has one property - but in the future it might cause issues if (for example) the metrics lib just returns a new config with the pattern but any other properties on the config are not copied.

If you have other thoughts on how to do this then happy to change.