### PR TITLE
Fix stackoverflow when no tracer available (so obtains NoopTracer) bu…

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.tracerresolver.TracerResolver;
 import io.opentracing.util.GlobalTracer;
@@ -24,26 +25,30 @@ public class TracerAutoConfiguration {
      * <ol>
      *     <li>Tracer registered in {@link GlobalTracer#register(Tracer)}</li>
      *     <li>Tracer resolved from {@link TracerResolver#resolve()}</li>
-     *     <li>Default tracer from {@link GlobalTracer#get()}, which is {@link io.opentracing.NoopTracer}</li>
+     *     <li>Default tracer, which is {@link io.opentracing.NoopTracer}</li>
      * </ol>
      * @return tracer
      */
     @Bean
     @ConditionalOnMissingBean(Tracer.class)
     public Tracer getTracer() {
-
-        if (!GlobalTracer.isRegistered()) {
-            Tracer resolvedTracer = TracerResolver.resolveTracer();
-            if (resolvedTracer != null) {
-                GlobalTracer.register(resolvedTracer);
-            }
-        } else {
+        Tracer tracer;
+        if (GlobalTracer.isRegistered()) {
             log.warn("GlobalTracer is already registered. For consistency it is best practice to provide " +
                     "a Tracer bean instead of manually registering it with the GlobalTracer");
+            tracer = GlobalTracer.get();
+        } else {
+            tracer = TracerResolver.resolveTracer();
+            if (tracer == null) {
+                // WARNING: Don't return GlobalTracer.get() as this will result in a
+                // stack overflow if the returned tracer is subsequently wrapped by a
+                // BeanPostProcessor. The post processed tracer would then be registered
+                // with the {@link GlobalTracer) (via the {@link TracerRegisterAutoConfiguration})
+                // resulting in the wrapper both wrapping the GlobalTracer, as well as being
+                // the tracer used by the GlobalTracer.
+                tracer = NoopTracerFactory.create();
+            }
         }
-
-        Tracer tracerToReturn = GlobalTracer.get();
-        log.warn("Tracer bean is not configured! Switching to " + tracerToReturn);
-        return tracerToReturn;
+        return tracer;
     }
 }

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfiguration.java
@@ -49,6 +49,7 @@ public class TracerAutoConfiguration {
                 tracer = NoopTracerFactory.create();
             }
         }
+        log.warn("Tracer bean is not configured! Switching to " + tracer);
         return tracer;
     }
 }

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/AsyncRestTemplateAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/AsyncRestTemplateAutoConfigurationTest.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutionException;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = {AsyncRestTemplateAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
-public class AsyncRestTemplateAutoConfigurationTest {
+public class AsyncRestTemplateAutoConfigurationTest extends AutoConfigurationBaseTest  {
 
     @Configuration
     @EnableAutoConfiguration

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/AutoConfigurationBaseTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/AutoConfigurationBaseTest.java
@@ -1,0 +1,28 @@
+package io.opentracing.contrib.spring.web.autoconfig;
+
+import java.lang.reflect.Field;
+import org.junit.BeforeClass;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Tracer;
+import io.opentracing.util.GlobalTracer;
+
+public class AutoConfigurationBaseTest {
+
+    // Temporary solution until https://github.com/opentracing/opentracing-java/issues/170 resolved
+    private static void _setGlobal(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
+        }
+    }
+
+    @BeforeClass
+    public static void clearGlobalTracer() {
+        _setGlobal(NoopTracerFactory.create());
+    }
+
+}

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/RestTemplateAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/RestTemplateAutoConfigurationTest.java
@@ -24,7 +24,7 @@ import io.opentracing.util.ThreadLocalActiveSpanSource;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = {RestTemplateAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
-public class RestTemplateAutoConfigurationTest {
+public class RestTemplateAutoConfigurationTest extends AutoConfigurationBaseTest  {
 
     @Configuration
     @EnableAutoConfiguration

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfigurationTest.java
@@ -25,7 +25,7 @@ import io.opentracing.util.ThreadLocalActiveSpanSource;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = {ServerTracingAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
-public class ServerTracingAutoConfigurationTest {
+public class ServerTracingAutoConfigurationTest extends AutoConfigurationBaseTest  {
 
     @Configuration
     @EnableAutoConfiguration

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TestTracerBeanPostProcessor.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TestTracerBeanPostProcessor.java
@@ -1,0 +1,63 @@
+package io.opentracing.contrib.spring.web.autoconfig;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Configuration;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+
+@Configuration
+public class TestTracerBeanPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof Tracer) {
+            return new TracerWrapper((Tracer)bean);
+        }
+        return bean;
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+
+    public static class TracerWrapper implements Tracer {
+
+        private Tracer wrapped;
+        
+        public TracerWrapper(Tracer wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public ActiveSpan activeSpan() {
+            return wrapped.activeSpan();
+        }
+
+        @Override
+        public ActiveSpan makeActive(Span span) {
+            return wrapped.makeActive(span);
+        }
+
+        @Override
+        public SpanBuilder buildSpan(String operationName) {
+            return wrapped.buildSpan(operationName);
+        }
+
+        @Override
+        public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+             wrapped.inject(spanContext, format, carrier);
+        }
+
+        @Override
+        public <C> SpanContext extract(Format<C> format, C carrier) {
+            return wrapped.extract(format, carrier);
+        }
+        
+    }
+}

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
@@ -4,21 +4,45 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Field;
+
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
 import io.opentracing.util.GlobalTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
 
 @SpringBootTest(
         classes = {TracerAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
 public class TracerAutoConfigurationTest {
+
+    // Temporary solution until https://github.com/opentracing/opentracing-java/issues/170 resolved
+    private static void _setGlobal(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
+        }
+    }
+
+    @BeforeClass
+    public static void clearGlobalTracer() {
+        _setGlobal(NoopTracerFactory.create());
+    }
 
     @Autowired
     private Tracer tracer;
@@ -26,13 +50,18 @@ public class TracerAutoConfigurationTest {
     @Configuration
     @EnableAutoConfiguration
     public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer(new ThreadLocalActiveSpanSource());
+        }
     }
 
     @Test
     public void testGetAutoWiredTracer() {
         assertNotNull(tracer);
         assertTrue(GlobalTracer.isRegistered());
-        assertEquals(tracer, GlobalTracer.get());
+        GlobalTracer.get().buildSpan("hello").startManual().finish();
+        assertEquals(1, ((MockTracer)tracer).finishedSpans().size());
     }
 
 }

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
@@ -1,7 +1,6 @@
 package io.opentracing.contrib.spring.web.autoconfig;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -37,7 +36,7 @@ public class TracerAutoConfigurationTest extends AutoConfigurationBaseTest {
 
     @Test
     public void testGetAutoWiredTracer() {
-        assertNotNull(tracer);
+        assertTrue(tracer instanceof MockTracer);
         assertTrue(GlobalTracer.isRegistered());
         GlobalTracer.get().buildSpan("hello").startManual().finish();
         assertEquals(1, ((MockTracer)tracer).finishedSpans().size());

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationTest.java
@@ -4,9 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Field;
-
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +13,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import io.opentracing.NoopTracerFactory;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.util.GlobalTracer;
@@ -25,24 +21,7 @@ import io.opentracing.util.ThreadLocalActiveSpanSource;
 @SpringBootTest(
         classes = {TracerAutoConfigurationTest.SpringConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
-public class TracerAutoConfigurationTest {
-
-    // Temporary solution until https://github.com/opentracing/opentracing-java/issues/170 resolved
-    private static void _setGlobal(Tracer tracer) {
-        try {
-            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
-            globalTracerField.setAccessible(true);
-            globalTracerField.set(null, tracer);
-            globalTracerField.setAccessible(false);
-        } catch (Exception e) {
-            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
-        }
-    }
-
-    @BeforeClass
-    public static void clearGlobalTracer() {
-        _setGlobal(NoopTracerFactory.create());
-    }
+public class TracerAutoConfigurationTest extends AutoConfigurationBaseTest {
 
     @Autowired
     private Tracer tracer;

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
@@ -1,6 +1,5 @@
 package io.opentracing.contrib.spring.web.autoconfig;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.BeforeClass;
@@ -39,7 +38,7 @@ public class TracerAutoConfigurationWithWrapperAndRegisteredTracerTest extends A
 
     @Test
     public void testGetAutoWiredTracer() {
-        assertNotNull(tracer);
+        assertTrue(tracer instanceof TestTracerBeanPostProcessor.TracerWrapper);
         assertTrue(GlobalTracer.isRegistered());
         assertTrue(tracer.buildSpan("hello").startManual() instanceof MockSpan);
     }

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.java
@@ -3,6 +3,7 @@ package io.opentracing.contrib.spring.web.autoconfig;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,15 +12,22 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import io.opentracing.NoopSpan;
 import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
 import io.opentracing.util.GlobalTracer;
 
 @SpringBootTest(
-        classes = {TracerAutoConfigurationWithWrapperTest.SpringConfiguration.class,
+        classes = {TracerAutoConfigurationWithWrapperAndRegisteredTracerTest.SpringConfiguration.class,
                 TestTracerBeanPostProcessor.class})
 @RunWith(SpringJUnit4ClassRunner.class)
-public class TracerAutoConfigurationWithWrapperTest extends AutoConfigurationBaseTest {
+public class TracerAutoConfigurationWithWrapperAndRegisteredTracerTest extends AutoConfigurationBaseTest {
+
+    @BeforeClass
+    public static void setGlobalTracer() {
+        // Pre-register a tracer with the GlobalTracer
+        GlobalTracer.register(new MockTracer());
+    }
 
     @Autowired
     private Tracer tracer;
@@ -32,11 +40,8 @@ public class TracerAutoConfigurationWithWrapperTest extends AutoConfigurationBas
     @Test
     public void testGetAutoWiredTracer() {
         assertNotNull(tracer);
-        // No tracer has actually been provided, but there is a wrapper created
-        // in a BeanPostProcessor, so this wrapper around the NoopTracer gets
-        // registered with the GlobalTracer.
         assertTrue(GlobalTracer.isRegistered());
-        assertTrue(tracer.buildSpan("hello").startManual() instanceof NoopSpan);
+        assertTrue(tracer.buildSpan("hello").startManual() instanceof MockSpan);
     }
 
 }

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperTest.java
@@ -1,6 +1,5 @@
 package io.opentracing.contrib.spring.web.autoconfig;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -31,7 +30,7 @@ public class TracerAutoConfigurationWithWrapperTest extends AutoConfigurationBas
 
     @Test
     public void testGetAutoWiredTracer() {
-        assertNotNull(tracer);
+        assertTrue(tracer instanceof TestTracerBeanPostProcessor.TracerWrapper);
         // No tracer has actually been provided, but there is a wrapper created
         // in a BeanPostProcessor, so this wrapper around the NoopTracer gets
         // registered with the GlobalTracer.

--- a/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperTest.java
+++ b/opentracing-spring-web-autoconfigure/src/test/java/io/opentracing/contrib/spring/web/autoconfig/TracerAutoConfigurationWithWrapperTest.java
@@ -1,0 +1,119 @@
+package io.opentracing.contrib.spring.web.autoconfig;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.NoopSpan;
+import io.opentracing.NoopTracerFactory;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.util.GlobalTracer;
+
+@SpringBootTest(
+        classes = {TracerAutoConfigurationWithWrapperTest.SpringConfiguration.class,
+                TracerAutoConfigurationWithWrapperTest.TestTracerBeanPostProcessor.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TracerAutoConfigurationWithWrapperTest {
+
+    // Temporary solution until https://github.com/opentracing/opentracing-java/issues/170 resolved
+    private static void _setGlobal(Tracer tracer) {
+        try {
+            Field globalTracerField = GlobalTracer.class.getDeclaredField("tracer");
+            globalTracerField.setAccessible(true);
+            globalTracerField.set(null, tracer);
+            globalTracerField.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException("Error reflecting globalTracer: " + e.getMessage(), e);
+        }
+    }
+
+    @BeforeClass
+    public static void clearGlobalTracer() {
+        _setGlobal(NoopTracerFactory.create());
+    }
+
+    @Autowired
+    private Tracer tracer;
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+    }
+
+    @Test
+    public void testGetAutoWiredTracer() {
+        assertNotNull(tracer);
+        // No tracer has actually been provided, but there is a wrapper created
+        // in a BeanPostProcessor, so this wrapper around the NoopTracer gets
+        // registered with the GlobalTracer.
+        assertTrue(GlobalTracer.isRegistered());
+        assertTrue(tracer.buildSpan("hello").startManual() instanceof NoopSpan);
+    }
+
+    @Configuration
+    public static class TestTracerBeanPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+            if (bean instanceof Tracer) {
+                return new TracerWrapper((Tracer)bean);
+            }
+            return bean;
+        }
+
+        @Override
+        public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+            return bean;
+        }
+    }
+
+    public static class TracerWrapper implements Tracer {
+
+        private Tracer wrapped;
+        
+        public TracerWrapper(Tracer wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public ActiveSpan activeSpan() {
+            return wrapped.activeSpan();
+        }
+
+        @Override
+        public ActiveSpan makeActive(Span span) {
+            return wrapped.makeActive(span);
+        }
+
+        @Override
+        public SpanBuilder buildSpan(String operationName) {
+            return wrapped.buildSpan(operationName);
+        }
+
+        @Override
+        public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
+             wrapped.inject(spanContext, format, carrier);
+        }
+
+        @Override
+        public <C> SpanContext extract(Format<C> format, C carrier) {
+            return wrapped.extract(format, carrier);
+        }
+        
+    }
+}


### PR DESCRIPTION
…t a wrapper (via BeanPostProcessor) changes the wired Tracer to the wrapped type, which then gets registered with the GlobalTracer via the TracerRegisterAutoConfiguration - which results in the wrapper wrapping the GlobalTracer as well as being the tracer that it wraps.

The end result is that any call to the tracer results in a stack overflow. It only works if the tracer resolver finds a tracer implementation.

Signed-off-by: Gary Brown <gary@brownuk.com>