### PR TITLE
Define explicit dependency from auto configs on the tracer auto confi…

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/AsyncRestTemplateAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/AsyncRestTemplateAutoConfiguration.java
@@ -2,7 +2,11 @@ package io.opentracing.contrib.spring.web.autoconfig;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.web.client.TracingAsyncRestTemplateInterceptor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
@@ -18,7 +22,9 @@ import java.util.Set;
  */
 @Configuration
 @ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
 public class AsyncRestTemplateAutoConfiguration {
+    private static final Log log = LogFactory.getLog(AsyncRestTemplateAutoConfiguration.class);
 
     @Autowired(required = false)
     private Set<AsyncRestTemplate> restTemplates;
@@ -44,6 +50,7 @@ public class AsyncRestTemplateAutoConfiguration {
             }
         }
 
+        log.info("Adding " + TracingAsyncRestTemplateInterceptor.class.getSimpleName() + " to async rest template");
         interceptors = new ArrayList<>(interceptors);
         interceptors.add(new TracingAsyncRestTemplateInterceptor(tracer));
         restTemplate.setInterceptors(interceptors);

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/RestTemplateAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/RestTemplateAutoConfiguration.java
@@ -6,7 +6,10 @@ import java.util.Set;
 
 import javax.annotation.PostConstruct;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
@@ -20,7 +23,9 @@ import io.opentracing.contrib.spring.web.client.TracingRestTemplateInterceptor;
  */
 @Configuration
 @ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
 public class RestTemplateAutoConfiguration {
+    private static final Log log = LogFactory.getLog(RestTemplateAutoConfiguration.class);
 
     @Autowired(required = false)
     private Set<RestTemplate> restTemplates;
@@ -46,6 +51,7 @@ public class RestTemplateAutoConfiguration {
             }
         }
 
+        log.info("Adding " + TracingRestTemplateInterceptor.class.getSimpleName() + " to rest template");
         interceptors = new ArrayList<>(interceptors);
         interceptors.add(new TracingRestTemplateInterceptor(tracer));
         restTemplate.setInterceptors(interceptors);

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfiguration.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
@@ -28,6 +28,7 @@ import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 @Configuration
 @ConditionalOnWebApplication
 @ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
 public class ServerTracingAutoConfiguration {
     private static final Log log = LogFactory.getLog(ServerTracingAutoConfiguration.class);
 

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerRegisterAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/TracerRegisterAutoConfiguration.java
@@ -3,6 +3,7 @@ package io.opentracing.contrib.spring.web.autoconfig;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,6 +15,7 @@ import io.opentracing.util.GlobalTracer;
  */
 @Configuration
 @ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
 public class TracerRegisterAutoConfiguration {
 
     @Autowired


### PR DESCRIPTION
…guration to avoid ordering issue where instrumentation not added due to Tracer bean not yet being available. This has been an issue since @ConditionalOnBean(Tracer.class) annotations added in 0.0.10.

Signed-off-by: Gary Brown <gary@brownuk.com>