### PR TITLE
Setting "error" tag in case of exception

### DIFF
--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/HandlerInterceptorSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/HandlerInterceptorSpanDecorator.java
@@ -1,6 +1,7 @@
 package io.opentracing.contrib.spring.web.interceptor;
 
 import io.opentracing.BaseSpan;
+import io.opentracing.tag.Tags;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.method.HandlerMethod;
 
@@ -119,6 +120,28 @@ public interface HandlerInterceptorSpanDecorator {
         }
     };
 
+    /**
+     * Sets a standard "error" tag in case of exception thrown during request processing
+     */
+    HandlerInterceptorSpanDecorator ERROR_TAG = new HandlerInterceptorSpanDecorator() {
+
+        @Override
+        public void onPreHandle(HttpServletRequest httpServletRequest, Object handler, BaseSpan<?> span) {
+        }
+
+        @Override
+        public void onAfterCompletion(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+                                      Object handler, Exception ex, BaseSpan<?> span) {
+            if (ex != null) {
+                Tags.ERROR.set(span, Boolean.TRUE);
+            }
+        }
+
+        @Override
+        public void onAfterConcurrentHandlingStarted(HttpServletRequest httpServletRequest,
+                                                     HttpServletResponse httpServletResponse, Object handler, BaseSpan<?> span) {
+        }
+    };
     /**
      * Helper class for deriving tags/logs from handler object.
      */

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -41,7 +41,8 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
     @Autowired
     public TracingHandlerInterceptor(Tracer tracer) {
         this(tracer, Arrays.asList(HandlerInterceptorSpanDecorator.STANDARD_LOGS,
-                HandlerInterceptorSpanDecorator.HANDLER_METHOD_OPERATION_NAME));
+                HandlerInterceptorSpanDecorator.HANDLER_METHOD_OPERATION_NAME,
+                HandlerInterceptorSpanDecorator.ERROR_TAG));
     }
 
     /**


### PR DESCRIPTION
"error" tag is one of [standard Opentracing tags](https://github.com/opentracing/specification/blob/master/semantic_conventions.md), it indicates that a failure happened during processing of a request. This PR implements setting such a tag in case processing of HTTP request thrown an Exception. Basically, it complements functionality of Client Interceptors, but helps to detect quickly if error happened on server side (useful if the client does not support tracing and the trace originates on the server).