### PR TITLE
Make possible to create TracingHandlerInterceptor via spring xml

### DIFF
--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -48,7 +48,6 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
      * @param tracer tracer
      * @param decorators span decorators
      */
-    @Autowired
     public TracingHandlerInterceptor(Tracer tracer, List<HandlerInterceptorSpanDecorator> decorators) {
         this.tracer = tracer;
         this.decorators = new ArrayList<>(decorators);

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorIntegrationTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorIntegrationTest.java
@@ -1,0 +1,22 @@
+package io.opentracing.contrib.spring.web.interceptor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("classpath:/test-context.xml")
+public class TracingHandlerInterceptorIntegrationTest {
+    @Autowired
+    TracingHandlerInterceptor interceptor;
+
+    @Test
+    public void testAutowired() {
+        assertNotNull(interceptor);
+    }
+}

--- a/opentracing-spring-web/src/test/resources/test-context.xml
+++ b/opentracing-spring-web/src/test/resources/test-context.xml
@@ -1,0 +1,11 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+
+    <bean name="tracer" class="io.opentracing.mock.MockTracer"/>
+    <bean class="io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor">
+        <constructor-arg type="io.opentracing.Tracer" ref="tracer"/>
+    </bean>
+</beans>


### PR DESCRIPTION
Hi! 

Thank you for the very useful project! I encounter an issue, currently, it is not possible to create an instance of `TracingHandlerInterceptor` via spring xml config. 

From [spring docs](https://docs.spring.io/spring/docs/5.0.x/spring-framework-reference/core.html#beans-autowired-annotation):

> Only one annotated constructor per-class can be marked as required, but multiple non-required constructors can be annotated. In that case, each is considered among the candidates and Spring uses the greediest constructor whose dependencies can be satisfied, that is the constructor that has the largest number of arguments.

`TracingHandlerInterceptor` has 2 constructors annotated with `required=true` (default) which is against the spec. Therefore, during creation the exception will be thrown:
```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor#0': Invalid autowire-marked constructor: public io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor(io.opentracing.Tracer,java.util.List). Found constructor with 'required' Autowired annotation already: public io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor(io.opentracing.Tracer)
```
The test demostrates the problem.

It can be fixed in 2 ways - annotate both constructors as `required=false` or remove one of them what I've done in this PR. 