### PR TITLE
Remove unnecessary @Autowired annotation from constructor

### DIFF
--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -9,7 +9,6 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
 import io.opentracing.ActiveSpan;
@@ -38,7 +37,6 @@ public class TracingHandlerInterceptor extends HandlerInterceptorAdapter {
     /**
      * @param tracer
      */
-    @Autowired
     public TracingHandlerInterceptor(Tracer tracer) {
         this(tracer, Arrays.asList(HandlerInterceptorSpanDecorator.STANDARD_LOGS,
                 HandlerInterceptorSpanDecorator.HANDLER_METHOD_OPERATION_NAME));

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorJavaConfigIntegrationTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorJavaConfigIntegrationTest.java
@@ -1,0 +1,41 @@
+package io.opentracing.contrib.spring.web.interceptor;
+
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = TracingHandlerInterceptorJavaConfigIntegrationTest.TestConfiguration.class)
+public class TracingHandlerInterceptorJavaConfigIntegrationTest {
+
+    @Autowired
+    private TracingHandlerInterceptor interceptor;
+
+    @Test
+    public void testAutowired() {
+        assertNotNull(interceptor);
+    }
+
+
+    @Configuration
+    static class TestConfiguration {
+
+        @Bean
+        TracingHandlerInterceptor tracingHandlerInterceptor(final Tracer tracer) {
+            return new TracingHandlerInterceptor(tracer);
+        }
+
+        @Bean
+        Tracer tracer() {
+            return new MockTracer();
+        }
+    }
+}

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorXmlConfigIntegrationTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorXmlConfigIntegrationTest.java
@@ -4,14 +4,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(SpringRunner.class)
 @ContextConfiguration("classpath:/test-context.xml")
-public class TracingHandlerInterceptorIntegrationTest {
+public class TracingHandlerInterceptorXmlConfigIntegrationTest {
     @Autowired
     TracingHandlerInterceptor interceptor;
 


### PR DESCRIPTION
Since TracingHandlerInterceptor is not annotated with one of the Spring
stereotype annotations but is instead meant to be created using explicit
Java or XML Configuration, the @Autowired annotation on the constructor
is no longer needed