### PR TITLE
Improve configurability of the ServerTracingAutoConfiguration

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfiguration.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/ServerTracingAutoConfiguration.java
@@ -25,6 +25,8 @@ import io.opentracing.contrib.spring.web.interceptor.TracingHandlerInterceptor;
 import io.opentracing.contrib.web.servlet.filter.ServletFilterSpanDecorator;
 import io.opentracing.contrib.web.servlet.filter.TracingFilter;
 
+import static java.lang.String.format;
+
 /**
  * @author Pavol Loffay
  * @author Eddú Meléndez
@@ -49,9 +51,10 @@ public class ServerTracingAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(TracingFilter.class)
     public FilterRegistrationBean tracingFilter(Tracer tracer, WebTracingProperties tracingConfiguration) {
-        log.info("Creating " + FilterRegistrationBean.class.getSimpleName() + " bean with " +
-                TracingFilter.class + " mapped to " + tracingConfiguration.getUrlPatterns().toString() +
-                ", skip pattern is " + tracingConfiguration.getSkipPattern());
+        log.info(format("Creating %s bean with %s mapped to %s, skip pattern is \"%s\"",
+                FilterRegistrationBean.class.getSimpleName(), TracingFilter.class.getSimpleName(),
+                tracingConfiguration.getUrlPatterns().toString(),
+                tracingConfiguration.getSkipPattern()));
 
         List<ServletFilterSpanDecorator> decorators = servletFilterSpanDecorator.getIfAvailable();
         if (CollectionUtils.isEmpty(decorators)) {

--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingProperties.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingProperties.java
@@ -1,5 +1,9 @@
 package io.opentracing.contrib.spring.web.autoconfig;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -14,6 +18,8 @@ public class WebTracingProperties {
             "/mappings|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream");
 
     private Pattern skipPattern = DEFAULT_SKIP_PATTERN;
+    private int order = Integer.MIN_VALUE;
+    private List<String> urlPatterns = Arrays.asList("/*");
 
     public Pattern getSkipPattern() {
         return skipPattern;
@@ -22,4 +28,21 @@ public class WebTracingProperties {
     public void setSkipPattern(Pattern skipPattern) {
         this.skipPattern = skipPattern;
     }
+
+    public List<String> getUrlPatterns() {
+        return urlPatterns;
+    }
+
+    public void setUrlPatterns(List<String> urlPatterns) {
+        this.urlPatterns = urlPatterns;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
 }

--- a/opentracing-spring-web-autoconfigure/src/test/resources/application-test.yml
+++ b/opentracing-spring-web-autoconfigure/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+opentracing:
+  spring:
+    web:
+      urlPatterns:
+        - /hello
+      order: 99


### PR DESCRIPTION
# Changes
While the current default were good, we needed more configuration for some project:
1. `order` and `urlPatterns` are now configurable
2. Project-specific ServletFilterSpanDecorator / HandlerInterceptorSpanDecorator beans can be provided to the ServerTracingAutoConfiguration (via ObjectProvider [1])

# Why this change?
1. `urlPatterns` can be useful to trace only some specific part of an application. As for `order`, it's always useful to have it in case you want to have another filter before this one.
2. While the SpanDecorator pattern is very nice, there was no way to use the ServerTracingAutoConfiguration along with a custom SpanDecorator.  

# Reference
[1] The usage of ObjectProvider is similar to the [RestTemplateAutoConfiguration of Spring Boot](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/web/client/RestTemplateAutoConfiguration.java)

cc @jfbreault