### PR TITLE
Fix to correctly use a List<> with Spring @Properties

### DIFF
--- a/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingProperties.java
+++ b/opentracing-spring-web-autoconfigure/src/main/java/io/opentracing/contrib/spring/web/autoconfig/WebTracingProperties.java
@@ -1,9 +1,6 @@
 package io.opentracing.contrib.spring.web.autoconfig;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,7 +16,7 @@ public class WebTracingProperties {
 
     private Pattern skipPattern = DEFAULT_SKIP_PATTERN;
     private int order = Integer.MIN_VALUE;
-    private List<String> urlPatterns = Arrays.asList("/*");
+    private List<String> urlPatterns = new ArrayList<>(Arrays.asList("/*"));
 
     public Pattern getSkipPattern() {
         return skipPattern;

--- a/opentracing-spring-web-autoconfigure/src/test/resources/application-test.yml
+++ b/opentracing-spring-web-autoconfigure/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 opentracing:
   spring:
     web:
-      urlPatterns: /hello, /excluded
+      urlPatterns:
+      - /hello
+      - /excluded
       order: 99
       skipPattern: "/excluded"


### PR DESCRIPTION
@pavolloffay I was wondering why you had to change the `application-test.yml` in https://github.com/opentracing-contrib/java-spring-web/pull/63 to make it work.

I guess it's because it was throwing a `java.lang.UnsupportedOperationException` when starting the context?

The problem was that when an List is already initialized in the Properties object, Spring add the items to it instead of replacing it by a new List. 
But the issue was that I used `Arrays.asList()` which [returns a fixed-size list](https://docs.oracle.com/javase/7/docs/api/java/util/Arrays.html#asList%28T...%29)