### PR TITLE
Generate spring-configuration-metadata.json for code autocompletion

### DIFF
--- a/opentracing-spring-web-autoconfigure/pom.xml
+++ b/opentracing-spring-web-autoconfigure/pom.xml
@@ -37,6 +37,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Added spring-boot-configuration-processor as Maven dependency
When metadata is missing, IDEA reports correct configuration as warning