### PR TITLE
Adding Header SpanDecorators to RestTemplate

### DIFF
--- a/opentracing-spring-web/pom.xml
+++ b/opentracing-spring-web/pom.xml
@@ -37,5 +37,10 @@
       <version>${version.org.springframework}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/decorator/RestTemplateHeaderSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/decorator/RestTemplateHeaderSpanDecorator.java
@@ -1,0 +1,100 @@
+package io.opentracing.contrib.spring.web.client.decorator;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.spring.web.client.RestTemplateSpanDecorator;
+import io.opentracing.tag.StringTag;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+/**
+ * RestTemplateHeaderSpanDecorator will decorate the span based on HTTP headers of the request.
+ * Prior to the request, the headers are compared to the {@link #allowedHeaders} list, if it's part
+ * of the provided list, they will be added as {@link StringTag}.
+ * The tag format will be a concatenation of {@link #prefix} and {@link HeaderEntry#tag}
+ */
+public class RestTemplateHeaderSpanDecorator  implements RestTemplateSpanDecorator, Ordered {
+
+    private final String prefix;
+    private final List<HeaderEntry> allowedHeaders;
+    private final int order;
+
+    public RestTemplateHeaderSpanDecorator(List<HeaderEntry> allowedHeaders) {
+        this(allowedHeaders, "http.header.");
+    }
+
+    public RestTemplateHeaderSpanDecorator(List<HeaderEntry> allowedHeaders, String prefix, int order) {
+        this.allowedHeaders = new ArrayList<>(allowedHeaders);
+        this.prefix = hasText(prefix) ? prefix : null;
+        this.order = order;
+    }
+
+    public RestTemplateHeaderSpanDecorator(List<HeaderEntry> allowedHeaders, String prefix) {
+        this(allowedHeaders, prefix, Ordered.LOWEST_PRECEDENCE + 20000);
+    }
+
+    @Override
+    public void onRequest(HttpRequest request, Span span) {
+        for (HeaderEntry headerEntry : allowedHeaders) {
+            String headerValue = request.getHeaders().getFirst(headerEntry.getHeader());
+            if (hasText(headerValue)) {
+                buildTag(headerEntry.getTag()).set(span, headerValue);
+            }
+        }
+    }
+
+    @Override
+    public void onResponse(HttpRequest request, ClientHttpResponse response, Span span) {
+    }
+
+    @Override
+    public void onError(HttpRequest request, Throwable ex, Span span) {
+    }
+
+    private StringTag buildTag(String tag) {
+        if (!hasText(prefix)) {
+            return new StringTag(tag);
+        }
+        return new StringTag(prefix + tag);
+    }
+
+    public String getPrefix() {
+        return this.prefix;
+    }
+
+    public List<HeaderEntry> getAllowedHeaders() {
+        return this.allowedHeaders;
+    }
+
+    public int getOrder() {
+        return this.order;
+    }
+
+    /**
+     * HeaderEntry is used to configure {@link RestTemplateHeaderSpanDecorator}
+     * {@link #header} is used to check if the header exists using {@link HttpRequest#getHeaders()}
+     * {@link #tag} will be used as a {@link StringTag} if {@link #header} is found on the request
+     */
+    public static class HeaderEntry {
+        private final String header;
+        private final String tag;
+
+        public HeaderEntry(String header, String tag) {
+            this.header = header;
+            this.tag = tag;
+        }
+
+        public String getHeader() {
+            return this.header;
+        }
+
+        public String getTag() {
+            return this.tag;
+        }
+    }
+
+}

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/decorator/RestTemplateHeaderSpanDecoratorTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/decorator/RestTemplateHeaderSpanDecoratorTest.java
@@ -1,0 +1,81 @@
+package io.opentracing.contrib.spring.web.client.decorator;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.spring.web.client.decorator.RestTemplateHeaderSpanDecorator.HeaderEntry;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestTemplateHeaderSpanDecoratorTest {
+
+    @Mock
+    private HttpRequest request;
+    @Mock
+    private HttpHeaders httpHeaders;
+
+    @Mock
+    private Span span;
+
+    private List<HeaderEntry> headerEntries = new ArrayList<>();
+
+    private RestTemplateHeaderSpanDecorator decorator;
+
+    @Before
+    public void init() {
+        when(request.getHeaders()).thenReturn(httpHeaders);
+        headerEntries.add(new HeaderEntry("If-Match", "if-match"));
+        decorator = new RestTemplateHeaderSpanDecorator(headerEntries);
+    }
+
+    @Test
+    public void givenMatchingHeaderEntry_whenOnRequest_thenItShouldAddTag() {
+        when(httpHeaders.getFirst("If-Match")).thenReturn("10");
+
+        decorator.onRequest(request, span);
+        verify(span).setTag("http.header.if-match", "10");
+    }
+
+    @Test
+    public void givenNonMatchingHeaderEntry_whenOnRequest_thenItShouldNotAddTag() {
+        decorator.onRequest(request, span);
+        verifyZeroInteractions(span);
+    }
+
+    @Test
+    public void givenEmptyMatchingHeaderEntry_whenOnRequest_thenItShouldNotAddTag() {
+        when(httpHeaders.getFirst("If-Match")).thenReturn("");
+
+        decorator.onRequest(request, span);
+        verifyZeroInteractions(span);
+    }
+
+    @Test
+    public void givenCustomTag_whenOnRequest_thenItShouldNotAddTag() {
+        decorator = new RestTemplateHeaderSpanDecorator(headerEntries, "HEADER.");
+        when(httpHeaders.getFirst("If-Match")).thenReturn("10");
+
+        decorator.onRequest(request, span);
+        verify(span).setTag("HEADER.if-match", "10");
+    }
+
+    @Test
+    public void givenEmptyCustomTag_whenOnRequest_thenItShouldNotAddTag() {
+        decorator = new RestTemplateHeaderSpanDecorator(headerEntries, "");
+        when(httpHeaders.getFirst("If-Match")).thenReturn("10");
+
+        decorator.onRequest(request, span);
+        verify(span).setTag("if-match", "10");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,12 @@
 
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.io.opentracing>0.31.0</version.io.opentracing>
-    <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.2.0</version.io.opentracing.contrib-opentracing-web-servlet-filter>
+    <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.2.2</version.io.opentracing.contrib-opentracing-web-servlet-filter>
     <version.io.opentracing.contrib-opentracing-tracerresolver>0.1.5</version.io.opentracing.contrib-opentracing-tracerresolver>
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
     <version.junit>4.12</version.junit>
     <version.org.mockito-mockito-core>1.10.19</version.org.mockito-mockito-core>
+    <version.assertj>3.9.0</version.assertj>
     <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
     <!-- Should match version from https://github.com/spring-projects/spring-boot/blob/1.5.x/spring-boot-dependencies/pom.xml  -->
     <version.org.springframework>4.3.16.RELEASE</version.org.springframework>
@@ -113,6 +114,11 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${version.org.mockito-mockito-core}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Similar to https://github.com/opentracing-contrib/java-web-servlet-filter/pull/49 but for RestTemplate.

There is 2 more PR related to this

cc @jfbreault