### PR TITLE
Do not auto-configure the tracing filter and tracing interceptor for reactive web servers.

### DIFF
--- a/opentracing-spring-web-starter/pom.xml
+++ b/opentracing-spring-web-starter/pom.xml
@@ -68,5 +68,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfiguration.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
  * @author Eddú Meléndez
  */
 @Configuration
-@ConditionalOnWebApplication
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnBean(Tracer.class)
 @AutoConfigureAfter(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(WebTracingProperties.class)

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDisabledForReactiveTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDisabledForReactiveTest.java
@@ -1,0 +1,46 @@
+package io.opentracing.contrib.spring.web.starter;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Gilles Robert
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {ServerTracingAutoConfigurationDisabledForReactiveTest.SpringConfiguration.class},
+    properties = {"spring.main.web-application-type=reactive"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("test")
+public class ServerTracingAutoConfigurationDisabledForReactiveTest extends AutoConfigurationBaseTest {
+
+  @Autowired(required = false)
+  @Qualifier("tracingFilter")
+  private FilterRegistrationBean tracingFilter;
+  @Autowired(required = false)
+  @Qualifier("tracingHandlerInterceptor")
+  private WebMvcConfigurerAdapter tracingHandlerInterceptor;
+
+  @Configuration
+  @EnableAutoConfiguration
+  public static class SpringConfiguration {
+
+  }
+
+  @Test
+  public void testWebConfigurationDisabled() {
+    assertNull(tracingFilter);
+    assertNull(tracingHandlerInterceptor);
+  }
+}


### PR DESCRIPTION
`TracingFilter` (the `FilterRegistrationBean` thereof) and `WebMvcConfigurerAdapter` are auto-configured even if the Spring Boot application is running on a reactive stack. This is unnecessary and the log message printed at startup can be a little confusing (since the beans are not actually doing anything).

Let's disable auto-configuration of these beans when the Spring Boot application is running on a reactive stack.