### PR TITLE
Add Spring WebFlux and WebClient tracing.

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0

--- a/header.txt
+++ b/header.txt
@@ -1,0 +1,11 @@
+Copyright ${license.git.copyrightYears} The OpenTracing Authors
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.

--- a/opentracing-spring-web-itest/boot/pom.xml
+++ b/opentracing-spring-web-itest/boot/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web-itest-boot</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web-itest/boot/src/main/webapp/WEB-INF/jsp/staticView.jsp
+++ b/opentracing-spring-web-itest/boot/src/main/webapp/WEB-INF/jsp/staticView.jsp
@@ -1,3 +1,18 @@
+<%--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+--%>
 <!DOCTYPE html>
 <body/>
 </html>

--- a/opentracing-spring-web-itest/boot/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/boot/BootITest.java
+++ b/opentracing-spring-web-itest/boot/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/boot/BootITest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.boot;
 
 import org.junit.runner.RunWith;

--- a/opentracing-spring-web-itest/boot/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/boot/SpringBootConfiguration.java
+++ b/opentracing-spring-web-itest/boot/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/boot/SpringBootConfiguration.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.boot;
 
 import java.util.Collections;

--- a/opentracing-spring-web-itest/boot/src/test/resources/application.properties
+++ b/opentracing-spring-web-itest/boot/src/test/resources/application.properties
@@ -1,2 +1,16 @@
+#
+# Copyright 2016-2019 The OpenTracing Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
 spring.mvc.view.prefix: WEB-INF/jsp/
 spring.mvc.view.suffix: .jsp

--- a/opentracing-spring-web-itest/common/pom.xml
+++ b/opentracing-spring-web-itest/common/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web-itest-common</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/AbstractBaseITests.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/AbstractBaseITests.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common;
 
 import io.opentracing.contrib.spring.web.interceptor.HandlerInterceptorSpanDecorator;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/ExceptionFilter.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/ExceptionFilter.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import java.io.IOException;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/SpanCheckerFilter.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/SpanCheckerFilter.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import io.opentracing.Span;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TestController.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TestController.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import java.util.concurrent.Callable;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TestInterceptor.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TestInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import javax.servlet.http.HttpServletRequest;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TracingBeansConfiguration.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/TracingBeansConfiguration.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import java.util.Arrays;

--- a/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/WebSecurityConfig.java
+++ b/opentracing-spring-web-itest/common/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/common/app/WebSecurityConfig.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.common.app;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/opentracing-spring-web-itest/mvc/pom.xml
+++ b/opentracing-spring-web-itest/mvc/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web-itest-mvc</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web-itest/mvc/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/mvc/MVCJettyITest.java
+++ b/opentracing-spring-web-itest/mvc/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/mvc/MVCJettyITest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.mvc;
 
 import java.util.Arrays;

--- a/opentracing-spring-web-itest/mvc/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/mvc/SpringMVCConfiguration.java
+++ b/opentracing-spring-web-itest/mvc/src/test/java/io/opentracing/contrib/spring/web/interceptor/itest/mvc/SpringMVCConfiguration.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor.itest.mvc;
 
 import java.util.Collections;

--- a/opentracing-spring-web-itest/mvc/src/test/webapp/WEB-INF/jsp/staticView.jsp
+++ b/opentracing-spring-web-itest/mvc/src/test/webapp/WEB-INF/jsp/staticView.jsp
@@ -1,3 +1,18 @@
+<%--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+--%>
 <!DOCTYPE html>
 <body/>
 </html>

--- a/opentracing-spring-web-itest/mvc/src/test/webapp/WEB-INF/web.xml
+++ b/opentracing-spring-web-itest/mvc/src/test/webapp/WEB-INF/web.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <web-app xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"

--- a/opentracing-spring-web-itest/pom.xml
+++ b/opentracing-spring-web-itest/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -9,6 +24,10 @@
 
   <artifactId>opentracing-spring-web-itest-parent</artifactId>
   <packaging>pom</packaging>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
 
   <modules>
     <module>common</module>

--- a/opentracing-spring-web-itest/pom.xml
+++ b/opentracing-spring-web-itest/pom.xml
@@ -14,6 +14,7 @@
     <module>common</module>
     <module>boot</module>
     <module>mvc</module>
+    <module>webflux</module>
   </modules>
 
   <build>

--- a/opentracing-spring-web-itest/webflux/pom.xml
+++ b/opentracing-spring-web-itest/webflux/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web-itest-webflux</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web-itest/webflux/pom.xml
+++ b/opentracing-spring-web-itest/webflux/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-web-itest-parent</artifactId>
+    <version>1.0.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opentracing-spring-web-itest-webflux</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>opentracing-spring-web-itest-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webflux</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
+++ b/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.webflux.webfilter.itest.webflux;
+
+import io.opentracing.contrib.spring.web.webfilter.TracingWebFilter;
+import io.opentracing.contrib.spring.web.webfilter.WebFluxSpanDecorator;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.boot.web.embedded.jetty.JettyReactiveWebServerFactory;
+import org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.HttpHandler;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebHandler;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * @author Csaba Kos
+ */
+public class WebFluxJettyMinimalIntegrationTest {
+
+    private static final ReactiveWebServerApplicationContext APPLICATION_CONTEXT = new ReactiveWebServerApplicationContext();
+    private static final MockTracer MOCK_TRACER = Mockito.spy(new MockTracer(new ThreadLocalScopeManager(),
+            MockTracer.Propagator.TEXT_MAP));
+    private final static TracingWebFilter TRACING_WEB_FILTER = new TracingWebFilter(
+            MOCK_TRACER,
+            Integer.MIN_VALUE,
+            Pattern.compile(""),
+            Collections.singletonList("/*"),
+            Arrays.asList(new WebFluxSpanDecorator.StandardTags(), new WebFluxSpanDecorator.WebFluxTags())
+    );
+    private static final int SERVER_PORT;
+    private static final TestRestTemplate TEST_REST_TEMPLATE;
+
+    static {
+        APPLICATION_CONTEXT.registerBean("jettyReactiveWebServerFactory", JettyReactiveWebServerFactory.class, () ->
+                new JettyReactiveWebServerFactory(0));
+        APPLICATION_CONTEXT.registerBean("webHandler", WebHandler.class, () ->
+                serverWebExchange -> TRACING_WEB_FILTER.filter(serverWebExchange, WebFluxJettyMinimalIntegrationTest::handler));
+        APPLICATION_CONTEXT.registerBean("httpHandler", HttpHandler.class, () ->
+                WebHttpHandlerBuilder.applicationContext(APPLICATION_CONTEXT).build());
+        APPLICATION_CONTEXT.refresh();
+        SERVER_PORT = APPLICATION_CONTEXT.getWebServer().getPort();
+        TEST_REST_TEMPLATE = new TestRestTemplate(new RestTemplateBuilder()
+                .rootUri("http://127.0.0.1:" + SERVER_PORT));
+    }
+
+    private static Mono<Void> handler(final ServerWebExchange serverWebExchange) {
+        final ServerHttpResponse response = serverWebExchange.getResponse();
+        response.setStatusCode(HttpStatus.OK);
+        return response.writeWith(Mono.just(new DefaultDataBufferFactory().wrap("Hello World!\n".getBytes())));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        APPLICATION_CONTEXT.close();
+    }
+
+    @Before
+    public void beforeTest() {
+        MOCK_TRACER.reset();
+        Mockito.reset(MOCK_TRACER);
+    }
+
+    @Test
+    public void testGet() {
+        TEST_REST_TEMPLATE.getForEntity("/", String.class);
+
+        final List<MockSpan> mockSpans = MOCK_TRACER.finishedSpans();
+        Assert.assertEquals(1, mockSpans.size());
+
+        final MockSpan span = mockSpans.get(0);
+        Assert.assertEquals("GET", span.operationName());
+
+        Assert.assertEquals(8, span.tags().size());
+        Assert.assertEquals(Tags.SPAN_KIND_SERVER, span.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", span.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(TEST_REST_TEMPLATE.getRootUri() + "/", span.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(200, span.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals("WebFlux/java-spring-web", span.tags().get(Tags.COMPONENT.getKey()));
+        Assert.assertNotNull(span.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals("127.0.0.1", span.tags().get(Tags.PEER_HOST_IPV4.getKey()));
+    }
+}

--- a/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
+++ b/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
@@ -105,7 +105,7 @@ public class WebFluxJettyMinimalIntegrationTest {
         Assert.assertEquals("GET", span.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(TEST_REST_TEMPLATE.getRootUri() + "/", span.tags().get(Tags.HTTP_URL.getKey()));
         Assert.assertEquals(200, span.tags().get(Tags.HTTP_STATUS.getKey()));
-        Assert.assertEquals("WebFlux/java-spring-web", span.tags().get(Tags.COMPONENT.getKey()));
+        Assert.assertEquals("java-spring-webflux", span.tags().get(Tags.COMPONENT.getKey()));
         Assert.assertNotNull(span.tags().get(Tags.PEER_PORT.getKey()));
         Assert.assertEquals("127.0.0.1", span.tags().get(Tags.PEER_HOST_IPV4.getKey()));
     }

--- a/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
+++ b/opentracing-spring-web-itest/webflux/src/test/java/io/opentracing/contrib/spring/webflux/webfilter/itest/webflux/WebFluxJettyMinimalIntegrationTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/pom.xml
+++ b/opentracing-spring-web-starter/pom.xml
@@ -27,7 +27,8 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webflux</artifactId>
-      <scope>provided</scope>
+      <scope>compile</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/opentracing-spring-web-starter/pom.xml
+++ b/opentracing-spring-web-starter/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webflux</artifactId>
-      <scope>compile</scope>
       <optional>true</optional>
     </dependency>
 

--- a/opentracing-spring-web-starter/pom.xml
+++ b/opentracing-spring-web-starter/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web-starter</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web-starter/pom.xml
+++ b/opentracing-spring-web-starter/pom.xml
@@ -24,6 +24,11 @@
       <artifactId>spring-webmvc</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webflux</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
@@ -66,6 +71,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty</artifactId>
+      <version>${version.io.projectreactor.netty-reactor-netty}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfiguration.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.Tracer;

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfiguration.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import java.util.Arrays;

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfiguration.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import io.opentracing.contrib.spring.web.client.TracingWebClientBeanPostProcessor;
+import io.opentracing.contrib.spring.web.client.WebClientSpanDecorator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+/**
+ * Instrumentation of {@link WebClient}. It also instruments {@link WebClient.Builder} and all instances created with it.
+ *
+ * @author Csaba Kos
+ */
+@Configuration
+@ConditionalOnBean(Tracer.class)
+@ConditionalOnClass(WebClient.class)
+@ConditionalOnProperty(prefix = WebClientTracingProperties.CONFIGURATION_PREFIX, name = "enabled", matchIfMissing = true)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
+@EnableConfigurationProperties(WebClientTracingProperties.class)
+public class WebClientTracingAutoConfiguration {
+    @ConditionalOnMissingBean(WebClientSpanDecorator.class)
+    @Configuration
+    static class DefaultWebClientSpanDecorators {
+        @Bean
+        WebClientSpanDecorator standardTagsWebClientSpanDecorator() {
+            return new WebClientSpanDecorator.StandardTags();
+        }
+    }
+
+    @Bean
+    public static TracingWebClientBeanPostProcessor tracingWebClientBeanPostProcessor(
+            final Tracer tracer,
+            final ObjectProvider<List<WebClientSpanDecorator>> webClientSpanDecorators
+    ) {
+        return new TracingWebClientBeanPostProcessor(
+                tracer,
+                webClientSpanDecorators.getObject()
+        );
+    }
+}

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfiguration.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingProperties.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingProperties.java
@@ -17,10 +17,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration for tracing of HTTP clients.
- * Supports RestTemplate and AsyncRestTemplate beans.
+ * Supports RestTemplate, AsyncRestTemplate, and WebClient beans.
  *
  * @author Michal Dvorak
- * @see RestTemplateTracingAutoConfiguration
+ * @see RestTemplateTracingAutoConfiguration,
+ * @see WebClientTracingAutoConfiguration
  * @since 4/5/18
  */
 @ConfigurationProperties(WebClientTracingProperties.CONFIGURATION_PREFIX)
@@ -29,7 +30,8 @@ public class WebClientTracingProperties {
     public static final String CONFIGURATION_PREFIX = WebTracingProperties.CONFIGURATION_PREFIX + ".client";
 
     /**
-     * When set to true (default), it enables automatic tracing of RestTemplate beans, as well as instances created using default RestTemplateBuilder bean.
+     * When set to true (default), it enables automatic tracing of RestTemplate, AsyncRestTemplate, and WebClient beans,
+     * as well as instances created using default RestTemplateBuilder and WebClient.Builder beans.
      * Does not affect instances created manually.
      */
     private boolean enabled = true;

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingProperties.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebClientTracingProperties.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import io.opentracing.contrib.spring.web.webfilter.TracingWebFilter;
+import io.opentracing.contrib.spring.web.webfilter.WebFluxSpanDecorator;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * Instrumentation of WebFlux.
+ *
+ * @author Csaba Kos
+ */
+@Configuration
+@ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
+@EnableConfigurationProperties(WebTracingProperties.class)
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
+@ConditionalOnProperty(name = "opentracing.spring.web.enabled", havingValue = "true", matchIfMissing = true)
+public class WebFluxTracingAutoConfiguration {
+    @ConditionalOnMissingBean(WebFluxSpanDecorator.class)
+    @Configuration
+    static class DefaultWebFluxSpanDecorators {
+        @Bean
+        WebFluxSpanDecorator standardTagsWebFluxSpanDecorator() {
+            return new WebFluxSpanDecorator.StandardTags();
+        }
+
+        @Bean
+        WebFluxSpanDecorator webFluxTagsWebFluxSpanDecorator() {
+            return new WebFluxSpanDecorator.WebFluxTags();
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(TracingWebFilter.class)
+    public TracingWebFilter traceFilter(
+            final Tracer tracer,
+            final WebTracingProperties webTracingProperties,
+            final ObjectProvider<List<WebFluxSpanDecorator>> webFilterSpanDecorators
+    ) {
+        return new TracingWebFilter(
+                tracer,
+                webTracingProperties.getOrder(),
+                webTracingProperties.getSkipPattern(),
+                webTracingProperties.getUrlPatterns(),
+                webFilterSpanDecorators.getObject()
+        );
+    }
+}

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
@@ -39,7 +39,7 @@ import java.util.List;
 @AutoConfigureAfter(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(WebTracingProperties.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
-@ConditionalOnProperty(name = "opentracing.spring.web.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(name = WebTracingProperties.CONFIGURATION_PREFIX + ".enabled", havingValue = "true", matchIfMissing = true)
 public class WebFluxTracingAutoConfiguration {
     @ConditionalOnMissingBean(WebFluxSpanDecorator.class)
     @Configuration

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfiguration.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import java.util.*;

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/client/TracingRestTemplateCustomizer.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/client/TracingRestTemplateCustomizer.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter.client;
 
 import io.opentracing.Tracer;

--- a/opentracing-spring-web-starter/src/main/resources/META-INF/spring.factories
+++ b/opentracing-spring-web-starter/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.opentracing.contrib.spring.web.starter.ServerTracingAutoConfiguration,\
-io.opentracing.contrib.spring.web.starter.RestTemplateTracingAutoConfiguration
+io.opentracing.contrib.spring.web.starter.RestTemplateTracingAutoConfiguration,\
+io.opentracing.contrib.spring.web.starter.WebClientTracingAutoConfiguration,\
+io.opentracing.contrib.spring.web.starter.WebFluxTracingAutoConfiguration

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/AsyncRestTemplatePostProcessingConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/AsyncRestTemplatePostProcessingConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.mock.MockTracer;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/AutoConfigurationBaseTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/AutoConfigurationBaseTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import java.lang.reflect.Field;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/CustomSpanDecoratorAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/CustomSpanDecoratorAutoConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.Span;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/DisabledRestTemplateTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/DisabledRestTemplateTracingAutoConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.contrib.spring.web.client.TracingRestTemplateInterceptor;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/RestTemplatePostProcessingConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/RestTemplatePostProcessingConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.mock.MockTracer;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDisabledTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDisabledTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import org.springframework.beans.factory.annotation.Autowired;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import java.util.concurrent.Callable;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/SkipPatternTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/SkipPatternTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.starter;
 
 import io.opentracing.mock.MockSpan;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfigurationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.net.URI;
+
+/**
+ * @author Csaba Kos
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {WebClientTracingAutoConfigurationTest.SpringConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class WebClientTracingAutoConfigurationTest extends AutoConfigurationBaseTest {
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer(new ThreadLocalScopeManager());
+        }
+
+        @Bean
+        public WebClient webClient() {
+            return WebClient.create();
+        }
+
+        @Bean
+        public WebClient.Builder webClientBuilder() {
+            return WebClient.builder();
+        }
+    }
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @Autowired
+    private WebClient webClient;
+
+    @Autowired
+    private WebClient.Builder webClientBuilder;
+
+    @Before
+    public void setUp() {
+        mockTracer.reset();
+    }
+
+    @Test
+    public void testWebClientAutoConfiguration() {
+        webClient.get()
+                .uri(URI.create("http://example.com"))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        Assert.assertEquals(1, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void testWebClientBuilderAutoConfiguration() {
+        webClientBuilder
+                .build()
+                .get()
+                .uri(URI.create("http://example.com"))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        Assert.assertEquals(1, mockTracer.finishedSpans().size());
+    }
+}

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebClientTracingAutoConfigurationTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDisabledTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDisabledTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.contrib.spring.web.webfilter.TracingWebFilter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Csaba Kos
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {WebFluxTracingAutoConfigurationDisabledTest.SpringConfiguration.class},
+    properties = {"opentracing.spring.web.enabled=false", "spring.main.web-application-type=reactive"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("test")
+public class WebFluxTracingAutoConfigurationDisabledTest extends AutoConfigurationBaseTest {
+
+  @Autowired(required = false)
+  private TracingWebFilter tracingWebFilter;
+
+  @Configuration
+  @EnableAutoConfiguration
+  public static class SpringConfiguration {
+
+    @Bean
+    public RestTemplate restTemplate() {
+      return new RestTemplate();
+    }
+
+    @Bean
+    public AsyncRestTemplate asyncRestTemplate() {
+      return new AsyncRestTemplate();
+    }
+  }
+
+  @Test
+  public void testWebConfigurationDisabled() {
+    assertNull(tracingWebFilter);
+  }
+}

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDisabledTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDisabledTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.contrib.spring.web.webfilter.TracingWebFilter;
+import io.opentracing.contrib.spring.web.webfilter.WebFluxSpanDecorator;
+import io.opentracing.mock.MockTracer;
+import org.awaitility.Awaitility;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Csaba Kos
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {WebFluxTracingAutoConfigurationTest.SpringConfiguration.class},
+        properties = {"opentracing.spring.web.client.enabled=false", "spring.main.web-application-type=reactive"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("test")
+public class WebFluxTracingAutoConfigurationTest extends AutoConfigurationBaseTest  {
+
+    private static CountDownLatch skipCountDownLatch = new CountDownLatch(1);
+    private static CountDownLatch excludeCountDownLatch = new CountDownLatch(1);
+
+    @RestController
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer();
+        }
+
+        @RequestMapping("/hello")
+        public void hello() {
+        }
+
+        @RequestMapping("/skip")
+        public void skip() {
+            skipCountDownLatch.countDown();
+        }
+
+        @RequestMapping("/excluded")
+        public void excluded() {
+            excludeCountDownLatch.countDown();
+        }
+    }
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @Autowired
+    private TracingWebFilter tracingWebFilter;
+
+    @MockBean
+    @Qualifier("mockDecorator1")
+    private WebFluxSpanDecorator mockDecorator1;
+    @MockBean
+    @Qualifier("mockDecorator2")
+    private WebFluxSpanDecorator mockDecorator2;
+
+    @Test
+    public void testRequestIsTraced() {
+        testRestTemplate.getForEntity("/hello", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+    }
+
+    @Test
+    public void testOnlyUrlPatternsIsTraced() throws InterruptedException {
+        testRestTemplate.getForEntity("/skip", String.class);
+        skipCountDownLatch.await();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);
+    }
+
+    @Test
+    public void testExcluded() throws InterruptedException {
+        testRestTemplate.getForEntity("/excluded", String.class);
+        excludeCountDownLatch.await();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(0);
+    }
+
+    @Test
+    public void testDecoratedProviderIsUsed() {
+        testRestTemplate.getForEntity("/hello", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(2);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(2);
+    }
+
+    @Test
+    public void testOrderIsUsed() {
+        // Ensure the loaded properties (application-test.yml) are used
+        assertThat(tracingWebFilter.getOrder()).isEqualTo(99);
+    }
+
+    public Callable<Integer> reportedSpansSize() {
+        return new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return mockTracer.finishedSpans().size();
+            }
+        };
+    }
+
+    @After()
+    public void reset() {
+        mockTracer.reset();
+        skipCountDownLatch = new CountDownLatch(1);
+        excludeCountDownLatch = new CountDownLatch(1);
+    }
+}

--- a/opentracing-spring-web-starter/src/test/resources/application-test.yml
+++ b/opentracing-spring-web-starter/src/test/resources/application-test.yml
@@ -1,3 +1,17 @@
+#
+# Copyright 2016-2018 The OpenTracing Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
 opentracing:
   spring:
     web:

--- a/opentracing-spring-web-starter/src/test/resources/application-test.yml
+++ b/opentracing-spring-web-starter/src/test/resources/application-test.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2018 The OpenTracing Authors
+# Copyright 2016-2019 The OpenTracing Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/pom.xml
+++ b/opentracing-spring-web/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -8,6 +23,10 @@
   </parent>
 
   <artifactId>opentracing-spring-web</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/opentracing-spring-web/pom.xml
+++ b/opentracing-spring-web/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webflux</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/opentracing-spring-web/pom.xml
+++ b/opentracing-spring-web/pom.xml
@@ -21,6 +21,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-webflux</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
@@ -35,6 +40,18 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <version>${version.org.springframework}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-jre8</artifactId>
+      <version>${version.com.github.tomakehurst-wiremock-jre8}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor.netty</groupId>
+      <artifactId>reactor-netty</artifactId>
+      <version>${version.io.projectreactor.netty-reactor-netty}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/HttpHeadersCarrier.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/HttpHeadersCarrier.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import io.opentracing.propagation.TextMap;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/RestTemplateSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/RestTemplateSpanDecorator.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import java.io.IOException;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import java.io.IOException;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseMono.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseMono.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.client;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.util.context.Context;
+
+import java.util.List;
+
+/**
+ * Similar to {@code MonoWebClientTrace} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+class TracingClientResponseMono extends Mono<ClientResponse> {
+    private final ClientRequest request;
+    private final ExchangeFunction next;
+    private final Tracer tracer;
+    private final List<WebClientSpanDecorator> spanDecorators;
+
+    TracingClientResponseMono(
+            final ClientRequest clientRequest,
+            final ExchangeFunction next,
+            final Tracer tracer,
+            final List<WebClientSpanDecorator> spanDecorators
+    ) {
+        this.request = clientRequest;
+        this.next = next;
+        this.tracer = tracer;
+        this.spanDecorators = spanDecorators;
+    }
+
+    @Override
+    public void subscribe(final CoreSubscriber<? super ClientResponse> subscriber) {
+        final Context context = subscriber.currentContext();
+        final Span parentSpan = context.<Span>getOrEmpty(Span.class).orElseGet(tracer::activeSpan);
+
+        final Span span = tracer.buildSpan(request.method().toString())
+                .asChildOf(parentSpan)
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CLIENT)
+                .start();
+
+        try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+            final ClientRequest.Builder requestBuilder = ClientRequest.from(request);
+            requestBuilder.headers(httpHeaders ->
+                    tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS, new HttpHeadersCarrier(httpHeaders)));
+            final ClientRequest mutatedRequest = requestBuilder.build();
+
+            next.exchange(mutatedRequest).subscribe(
+                    new TracingClientResponseSubscriber(subscriber, mutatedRequest, context, span, spanDecorators)
+            );
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseMono.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseMono.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.client;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
@@ -67,6 +67,7 @@ class TracingClientResponseSubscriber implements CoreSubscriber<ClientResponse> 
             public void cancel() {
                 spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onCancel(clientRequest, span)));
                 subscription.cancel();
+                span.finish();
             }
         });
     }

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.client;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingClientResponseSubscriber.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.client;
+
+import io.opentracing.Span;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Subscription;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+import java.util.List;
+
+/**
+ * Similar to {@code WebClientTracerSubscriber} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+class TracingClientResponseSubscriber implements CoreSubscriber<ClientResponse> {
+    private static final Log LOG = LogFactory.getLog(TracingClientResponseSubscriber.class);
+
+    private final CoreSubscriber<? super ClientResponse> subscriber;
+    private final ClientRequest clientRequest;
+    private final Context context;
+    private final Span span;
+    private final List<WebClientSpanDecorator> spanDecorators;
+
+    TracingClientResponseSubscriber(
+            final CoreSubscriber<? super ClientResponse> subscriber,
+            final ClientRequest clientRequest,
+            final Context context,
+            final Span span,
+            final List<WebClientSpanDecorator> spanDecorators
+    ) {
+        this.subscriber = subscriber;
+        this.clientRequest = clientRequest;
+        this.context = context.put(Span.class, span);
+        this.span = span;
+        this.spanDecorators = spanDecorators;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription subscription) {
+        spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onRequest(clientRequest, span)));
+
+        subscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(final long n) {
+                subscription.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onCancel(clientRequest, span)));
+                subscription.cancel();
+            }
+        });
+    }
+
+    @Override
+    public void onNext(final ClientResponse clientResponse) {
+        try {
+            // decorate response body
+            subscriber.onNext(ClientResponse.from(clientResponse)
+                    .body(clientResponse.bodyToFlux(DataBuffer.class).subscriberContext(context))
+                    .build());
+        } finally {
+            spanDecorators.forEach(spanDecorator ->
+                    safelyCall(() -> spanDecorator.onResponse(clientRequest, clientResponse, span)));
+        }
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        try {
+            subscriber.onError(throwable);
+        } finally {
+            spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onError(clientRequest, throwable, span)));
+            span.finish();
+        }
+    }
+
+    @Override
+    public void onComplete() {
+        try {
+            subscriber.onComplete();
+        } finally {
+            span.finish();
+        }
+    }
+
+    @Override
+    public Context currentContext() {
+        return context;
+    }
+
+    private void safelyCall(final Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (final RuntimeException e) {
+            LOG.error("Exception during decorating span", e);
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingExchangeFilterFunction.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingExchangeFilterFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.client;
+
+import io.opentracing.Tracer;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Similar to {@code TraceExchangeFilterFunction} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+public class TracingExchangeFilterFunction implements ExchangeFilterFunction {
+	private final Tracer tracer;
+	private final List<WebClientSpanDecorator> spanDecorators;
+
+	public TracingExchangeFilterFunction(final Tracer tracer, final List<WebClientSpanDecorator> spanDecorators) {
+		this.tracer = tracer;
+		this.spanDecorators = spanDecorators;
+	}
+
+	@Override
+	public Mono<ClientResponse> filter(final ClientRequest clientRequest, final ExchangeFunction next) {
+		return new TracingClientResponseMono(clientRequest, next, tracer, spanDecorators);
+	}
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingExchangeFilterFunction.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingExchangeFilterFunction.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.client;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import java.io.IOException;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingWebClientBeanPostProcessor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingWebClientBeanPostProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.client;
+
+import io.opentracing.Tracer;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * {@link BeanPostProcessor} for instrumenting {@link WebClient} with tracing.
+ *
+ * Similar to {@code TraceWebClientBeanPostProcessor} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+public class TracingWebClientBeanPostProcessor implements BeanPostProcessor {
+	private final Tracer tracer;
+	private final List<WebClientSpanDecorator> spanDecorators;
+
+	public TracingWebClientBeanPostProcessor(final Tracer tracer, final List<WebClientSpanDecorator> spanDecorators) {
+		this.tracer = tracer;
+		this.spanDecorators = spanDecorators;
+	}
+
+	@Override
+	public Object postProcessBeforeInitialization(final Object bean, final String beanName) throws BeansException {
+		return bean;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(final Object bean, final String beanName) throws BeansException {
+		if (bean instanceof WebClient) {
+			final WebClient webClient = (WebClient) bean;
+			return webClient.mutate()
+					.filters(addTraceExchangeFilterFunctionIfNotPresent()).build();
+		} else if (bean instanceof WebClient.Builder) {
+			final WebClient.Builder webClientBuilder = (WebClient.Builder) bean;
+			return webClientBuilder.filters(addTraceExchangeFilterFunctionIfNotPresent());
+		}
+		return bean;
+	}
+
+	private Consumer<List<ExchangeFilterFunction>> addTraceExchangeFilterFunctionIfNotPresent() {
+		return functions -> {
+			if (functions.stream()
+					.noneMatch(function -> function instanceof TracingExchangeFilterFunction)) {
+				functions.add(new TracingExchangeFilterFunction(tracer, spanDecorators));
+			}
+		};
+	}
+}
+

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingWebClientBeanPostProcessor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/TracingWebClientBeanPostProcessor.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.client;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
@@ -18,7 +18,6 @@ import io.opentracing.tag.Tags;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,8 +94,10 @@ public interface WebClientSpanDecorator {
 
         @Override
         public void onCancel(final ClientRequest httpRequest, final Span span) {
-            Tags.ERROR.set(span, Boolean.TRUE);
-            span.log(Collections.singletonMap("error.message", "CANCELLED"));
+            final Map<String, Object> logs = new HashMap<>(2);
+            logs.put("event", "cancelled");
+            logs.put("message", "The subscription was cancelled");
+            span.log(logs);
         }
 
         static Map<String, Object> errorLogs(final Throwable throwable) {

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
@@ -69,7 +69,7 @@ public interface WebClientSpanDecorator {
      * This decorator adds set of standard tags to the span.
      */
     class StandardTags implements WebClientSpanDecorator {
-        static final String COMPONENT_NAME = "WebClient/java-spring-web";
+        static final String COMPONENT_NAME = "java-spring-webclient";
 
         @Override
         public void onRequest(final ClientRequest clientRequest, final Span span) {

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/client/WebClientSpanDecorator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.client;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Decorate span by adding tags/logs or operation name change.
+ *
+ * <p>Do not finish span (otherwise some tags/logs might be missing)!
+ *
+ * @author Csaba Kos
+ */
+public interface WebClientSpanDecorator {
+
+    /**
+     * Decorate span before before request is executed, e.g. before {@code .onSubscribe()} is called.
+     *
+     * @param clientRequest request
+     * @param span client span
+     */
+    void onRequest(ClientRequest clientRequest, Span span);
+
+    /**
+     * Decorate span after the clientRequest is done, e.g. after {@code .onNext()} is called.
+     *
+     * @param clientRequest clientRequest
+     * @param clientResponse clientResponse
+     * @param span span
+     */
+    void onResponse(ClientRequest clientRequest, ClientResponse clientResponse, Span span);
+
+    /**
+     * Decorate span when exception is thrown during clientRequest processing, e.g. when {@code .onError()} is called.
+     *
+     * @param clientRequest clientRequest
+     * @param throwable exception
+     * @param span span
+     */
+    void onError(ClientRequest clientRequest, Throwable throwable, Span span);
+
+    /**
+     * Decorate span when the subscription is cancelled.
+     *
+     * @param clientRequest clientRequest
+     * @param span span
+     */
+    void onCancel(ClientRequest clientRequest, Span span);
+
+    /**
+     * This decorator adds set of standard tags to the span.
+     */
+    class StandardTags implements WebClientSpanDecorator {
+        static final String COMPONENT_NAME = "WebClient/java-spring-web";
+
+        @Override
+        public void onRequest(final ClientRequest clientRequest, final Span span) {
+            Tags.COMPONENT.set(span, COMPONENT_NAME);
+            Tags.HTTP_URL.set(span, clientRequest.url().toString());
+            Tags.HTTP_METHOD.set(span, clientRequest.method().toString());
+
+            if (clientRequest.url().getPort() != -1) {
+                Tags.PEER_PORT.set(span, clientRequest.url().getPort());
+            }
+        }
+
+        @Override
+        public void onResponse(final ClientRequest clientRequest, final ClientResponse clientResponse, final Span span) {
+            Tags.HTTP_STATUS.set(span, clientResponse.rawStatusCode());
+        }
+
+        @Override
+        public void onError(final ClientRequest clientRequest, final Throwable throwable, final Span span) {
+            Tags.ERROR.set(span, Boolean.TRUE);
+            span.log(errorLogs(throwable));
+        }
+
+        @Override
+        public void onCancel(final ClientRequest httpRequest, final Span span) {
+            Tags.ERROR.set(span, Boolean.TRUE);
+            span.log(Collections.singletonMap("error.message", "CANCELLED"));
+        }
+
+        static Map<String, Object> errorLogs(final Throwable throwable) {
+            final Map<String, Object> errorLogs = new HashMap<>(2);
+            errorLogs.put("event", Tags.ERROR.getKey());
+            errorLogs.put("error.object", throwable);
+            return errorLogs;
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/HandlerInterceptorSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/HandlerInterceptorSpanDecorator.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor;
 
 import io.opentracing.Span;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptor.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor;
 
 import java.util.ArrayDeque;

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/HttpHeadersExtractAdapter.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/HttpHeadersExtractAdapter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/HttpHeadersExtractAdapter.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/HttpHeadersExtractAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.webfilter;
+
+import io.opentracing.propagation.TextMap;
+import org.springframework.http.HttpHeaders;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Tracer extract adapter for {@link HttpHeaders}.
+ *
+ * @author Csaba Kos
+ */
+class HttpHeadersExtractAdapter implements TextMap {
+    private static final Stream<String> STREAM_OF_NULL = Stream.of(new String[]{ null });
+
+    private final HttpHeaders httpHeaders;
+
+    HttpHeadersExtractAdapter(final HttpHeaders httpHeaders) {
+        this.httpHeaders = httpHeaders;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return httpHeaders.entrySet()
+                .stream()
+                .flatMap(entry -> getValuesStream(entry.getValue())
+                        .map(value -> newEntry(entry.getKey(), value)))
+                .iterator();
+    }
+
+    private static Stream<String> getValuesStream(final List<String> values) {
+        return values.isEmpty() ? STREAM_OF_NULL : values.stream();
+    }
+
+    private static Map.Entry<String, String> newEntry(final String key, final String value) {
+        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+    @Override
+    public void put(String key, String value) {
+        throw new UnsupportedOperationException("This class should be used only with Tracer.inject()!");
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingOperator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingOperator.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.webfilter;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingOperator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingOperator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.webfilter;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.CoreSubscriber;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.MonoOperator;
+import reactor.util.context.Context;
+
+import java.util.List;
+
+/**
+ * Similar to {@code MonoWebFilterTrace} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+class TracingOperator extends MonoOperator<Void, Void> {
+    private final Tracer tracer;
+    private final ServerWebExchange exchange;
+    private final List<WebFluxSpanDecorator> spanDecorators;
+
+    TracingOperator(
+            final Mono<? extends Void> source,
+            final ServerWebExchange exchange,
+            final Tracer tracer,
+            final List<WebFluxSpanDecorator> spanDecorators
+    ) {
+        super(source);
+        this.tracer = tracer;
+        this.exchange = exchange;
+        this.spanDecorators = spanDecorators;
+    }
+
+    @Override
+    public void subscribe(final CoreSubscriber<? super Void> subscriber) {
+        final Context context = subscriber.currentContext();
+        final Span parentSpan = context.<Span>getOrEmpty(Span.class).orElseGet(tracer::activeSpan);
+        final ServerHttpRequest request = exchange.getRequest();
+
+        final SpanContext extractedContext;
+        if (parentSpan != null) {
+            extractedContext = parentSpan.context();
+        } else {
+            extractedContext = tracer.extract(Format.Builtin.HTTP_HEADERS, new HttpHeadersExtractAdapter(request.getHeaders()));
+        }
+
+        final Span span = tracer.buildSpan(request.getMethodValue())
+                .asChildOf(extractedContext)
+                .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
+                .start();
+
+        try (final Scope scope = tracer.scopeManager().activate(span, false)) {
+            exchange.getAttributes().put(TracingWebFilter.SERVER_SPAN_CONTEXT, span.context());
+            source.subscribe(new TracingSubscriber(subscriber, exchange, context, span, spanDecorators));
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriber.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriber.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.webfilter;
+
+import io.opentracing.Span;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Subscription;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
+
+import java.util.List;
+
+/**
+ * Similar to {@code WebFilterTraceSubscriber} from spring-could-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+class TracingSubscriber implements CoreSubscriber<Void> {
+    private static final Log LOG = LogFactory.getLog(TracingSubscriber.class);
+
+    private final CoreSubscriber<? super Void> subscriber;
+    private final ServerWebExchange exchange;
+    private final Context context;
+    private final Span span;
+    private final List<WebFluxSpanDecorator> spanDecorators;
+
+    TracingSubscriber(
+            final CoreSubscriber<? super Void> subscriber,
+            final ServerWebExchange exchange,
+            final Context context,
+            final Span span,
+            final List<WebFluxSpanDecorator> spanDecorators
+    ) {
+        this.subscriber = subscriber;
+        this.exchange = exchange;
+        this.context = context.put(Span.class, span);
+        this.span = span;
+        this.spanDecorators = spanDecorators;
+    }
+
+    @Override
+    public void onSubscribe(final Subscription subscription) {
+        spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onRequest(exchange, span)));
+        subscriber.onSubscribe(subscription);
+    }
+
+    @Override
+    public void onNext(final Void aVoid) {
+        // Never called
+        subscriber.onNext(aVoid);
+    }
+
+    @Override
+    public void onError(final Throwable throwable) {
+        spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onError(exchange, throwable, span)));
+        span.finish();
+        exchange.getAttributes().remove(TracingWebFilter.SERVER_SPAN_CONTEXT);
+        subscriber.onError(throwable);
+    }
+
+    @Override
+    public void onComplete() {
+        spanDecorators.forEach(spanDecorator -> safelyCall(() -> spanDecorator.onResponse(exchange, span)));
+        span.finish();
+        exchange.getAttributes().remove(TracingWebFilter.SERVER_SPAN_CONTEXT);
+        subscriber.onComplete();
+    }
+
+    @Override
+    public Context currentContext() {
+        return context;
+    }
+
+    private void safelyCall(final Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (final RuntimeException e) {
+            LOG.error("Exception during decorating span", e);
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriber.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriber.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.webfilter;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
@@ -1,15 +1,17 @@
 /*
- * Copyright 2016-2018 The OpenTracing Authors
+ * Copyright 2013-2019 the original author or authors. Copyright 2019 The OpenTracing Authors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.opentracing.contrib.spring.web.webfilter;
 

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.webfilter;
+
+import io.opentracing.Tracer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Tracing {@link WebFilter} for Spring WebFlux.
+ *
+ * Current server span context is accessible via {@link ServerWebExchange#getAttribute(String)} with name
+ * {@link TracingWebFilter#SERVER_SPAN_CONTEXT}.
+ *
+ * Based on {@code TraceWebFilter} from spring-cloud-sleuth-core.
+ *
+ * @author Csaba Kos
+ */
+public class TracingWebFilter implements WebFilter, Ordered {
+    private static final Log LOG = LogFactory.getLog(TracingWebFilter.class);
+
+    /**
+     * Used as a key of {@link ServerWebExchange#getAttributes()}} to inject server span context
+     */
+    static final String SERVER_SPAN_CONTEXT = TracingWebFilter.class.getName() + ".activeSpanContext";
+
+    private final Tracer tracer;
+    private final int order;
+    @Nullable
+    private final Pattern skipPattern;
+    private final Set<PathPattern> urlPatterns;
+    private final List<WebFluxSpanDecorator> spanDecorators;
+
+    public TracingWebFilter(
+            final Tracer tracer,
+            final int order,
+            final Pattern skipPattern,
+            final List<String> urlPatterns,
+            final List<WebFluxSpanDecorator> spanDecorators
+    ) {
+        this.tracer = tracer;
+        this.order = order;
+        this.skipPattern = (skipPattern != null && StringUtils.hasText(skipPattern.pattern())) ? skipPattern : null;
+        final PathPatternParser pathPatternParser = new PathPatternParser();
+        this.urlPatterns = urlPatterns.stream().map(pathPatternParser::parse).collect(Collectors.toSet());
+        this.spanDecorators = spanDecorators;
+    }
+
+    @Override
+    public Mono<Void> filter(final ServerWebExchange exchange, final WebFilterChain chain) {
+        final ServerHttpRequest request = exchange.getRequest();
+
+        if (!shouldBeTraced(request)) {
+            return chain.filter(exchange);
+        }
+
+        if (exchange.getAttribute(SERVER_SPAN_CONTEXT) != null) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Not tracing request " + request + " because it is already being traced");
+            }
+            return chain.filter(exchange);
+        }
+
+        return new TracingOperator(chain.filter(exchange), exchange, tracer, spanDecorators);
+    }
+
+    /**
+     * It checks whether a request should be traced or not.
+     *
+     * @return whether request should be traced or not
+     */
+    boolean shouldBeTraced(final ServerHttpRequest request) {
+        final PathContainer pathWithinApplication = request.getPath().pathWithinApplication();
+        // skip URLs matching skip pattern
+        // e.g. pattern is defined as '/health|/status' then URL 'http://localhost:5000/context/health' won't be traced
+        if (skipPattern != null) {
+            final String url = pathWithinApplication.value();
+            if (skipPattern.matcher(url).matches()) {
+                if (LOG.isTraceEnabled()) {
+                    LOG.trace("Not tracing request " + request + " because it matches skip pattern: " + skipPattern);
+                }
+                return false;
+            }
+        }
+        if (urlPatterns.stream().noneMatch(urlPattern -> urlPattern.matches(pathWithinApplication))) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("Not tracing request " + request + " because it does not match any URL pattern: " + urlPatterns);
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.webfilter;
+
+import io.opentracing.Span;
+import io.opentracing.tag.Tags;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.net.Inet6Address;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * SpanDecorator to decorate span at different stages in WebFlux processing (at subscription, after error or completion).
+ *
+ * @author Csaba Kos
+ */
+public interface WebFluxSpanDecorator {
+
+    /**
+     * Decorate span before {@code .onSubscribe()} is called. This is called right after span in created. Span
+     * context is already present in request attributes with name {@link TracingWebFilter#SERVER_SPAN_CONTEXT}.
+     *
+     * @param exchange web exchange
+     * @param span span to decorate
+     */
+    void onRequest(ServerWebExchange exchange, Span span);
+
+    /**
+     * Decorate span after successful completion.
+     *
+     * @param exchange web exchange
+     * @param span span to decorate
+     */
+    void onResponse(ServerWebExchange exchange, Span span);
+
+    /**
+     * Decorate span after completion in error.
+     *
+     * @param exchange web exchange
+     * @param exception exception
+     * @param span span to decorate
+     */
+    void onError(ServerWebExchange exchange, Throwable exception, Span span);
+
+    /**
+     * Adds standard tags to span. {@link Tags#HTTP_URL}, {@link Tags#HTTP_STATUS}, {@link Tags#HTTP_METHOD} and
+     * {@link Tags#COMPONENT}. In case of completion in error, tag {@link Tags#ERROR} is added and
+     * {@link Tags#HTTP_STATUS} not because at this point it is not known.
+     */
+    class StandardTags implements WebFluxSpanDecorator {
+        static final String COMPONENT_NAME = "WebFlux/java-spring-web";
+
+        @Override
+        public void onRequest(final ServerWebExchange exchange, final Span span) {
+            Tags.COMPONENT.set(span, COMPONENT_NAME);
+            final ServerHttpRequest request = exchange.getRequest();
+            Tags.HTTP_METHOD.set(span, request.getMethodValue());
+            Tags.HTTP_URL.set(span, request.getURI().toString());
+            Optional.ofNullable(request.getRemoteAddress()).ifPresent(remoteAddress -> {
+                Tags.PEER_HOSTNAME.set(span, remoteAddress.getHostString());
+                Tags.PEER_PORT.set(span, remoteAddress.getPort());
+                Optional.ofNullable(remoteAddress.getAddress()).ifPresent(
+                        inetAddress -> {
+                            if (inetAddress instanceof Inet6Address) {
+                                Tags.PEER_HOST_IPV6.set(span, inetAddress.getHostAddress());
+                            } else {
+                                Tags.PEER_HOST_IPV4.set(span, inetAddress.getHostAddress());
+                            }
+                        }
+                );
+            });
+        }
+
+        @Override
+        public void onResponse(final ServerWebExchange exchange, final Span span) {
+            Optional.ofNullable(exchange.getResponse().getStatusCode())
+                    .ifPresent(httpStatus -> Tags.HTTP_STATUS.set(span, httpStatus.value()));
+        }
+
+        @Override
+        public void onError(final ServerWebExchange exchange, final Throwable exception, final Span span) {
+            Tags.ERROR.set(span, Boolean.TRUE);
+            span.log(logsForException(exception));
+        }
+
+        private Map<String, Object> logsForException(final Throwable throwable) {
+            final Map<String, Object> errorLogs = new HashMap<>(2);
+            errorLogs.put("event", throwable instanceof TimeoutException ? "timed out" : Tags.ERROR.getKey());
+            errorLogs.put("error.object", throwable);
+            return errorLogs;
+        }
+    }
+
+    /**
+     * Adds tags from WebFlux handler to span.
+     */
+    class WebFluxTags implements WebFluxSpanDecorator {
+        @Override
+        public void onRequest(final ServerWebExchange exchange, final Span span) {
+            // No-op
+        }
+
+        @Override
+        public void onResponse(final ServerWebExchange exchange, final Span span) {
+            addWebFluxTags(exchange, span);
+        }
+
+        @Override
+        public void onError(final ServerWebExchange exchange, final Throwable exception, final Span span) {
+            addWebFluxTags(exchange, span);
+        }
+
+        private void addWebFluxTags(final ServerWebExchange exchange, final Span span) {
+            final Object handler = exchange.getAttribute(HandlerMapping.BEST_MATCHING_HANDLER_ATTRIBUTE);
+            if (handler == null) {
+                return;
+            }
+
+            final Map<String, Object> logs = new HashMap<>(4);
+            logs.put("event", "handle");
+
+            final Object pattern = exchange.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+            final String patternAsString = pattern == null ? null : pattern.toString();
+            if (pattern != null) {
+                logs.put("handler", patternAsString);
+            }
+
+            if (handler instanceof HandlerMethod) {
+                final HandlerMethod handlerMethod = (HandlerMethod) handler;
+                final String methodName = handlerMethod.getMethod().getName();
+                logs.put("handler.method_name", handlerMethod.getMethod().getName());
+                span.setOperationName(methodName);
+                logs.put("handler.class_simple_name", handlerMethod.getBeanType().getSimpleName());
+            } else {
+                if (pattern != null) {
+                    span.setOperationName(patternAsString);
+                }
+                logs.put("handler.class_simple_name", handler.getClass().getSimpleName());
+            }
+            span.log(logs);
+        }
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
@@ -65,7 +65,7 @@ public interface WebFluxSpanDecorator {
      * {@link Tags#HTTP_STATUS} not because at this point it is not known.
      */
     class StandardTags implements WebFluxSpanDecorator {
-        static final String COMPONENT_NAME = "WebFlux/java-spring-web";
+        static final String COMPONENT_NAME = "java-spring-webflux";
 
         @Override
         public void onRequest(final ServerWebExchange exchange, final Span span) {

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/package-info.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/package-info.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/package-info.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+@NonNullApi
+@NonNullFields
+
+package io.opentracing.contrib.spring.web.webfilter;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/AbstractTracingClientTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/AbstractTracingClientTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/AbstractTracingClientTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/AbstractTracingClientTest.java
@@ -1,90 +1,66 @@
 package io.opentracing.contrib.spring.web.client;
 
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.opentracing.Scope;
+import io.opentracing.Tracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.ThreadLocalScopeManager;
-
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpRequest;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.mock.http.client.MockClientHttpResponse;
-import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.test.web.client.ResponseCreator;
-import org.springframework.test.web.client.match.MockRestRequestMatchers;
-import org.springframework.test.web.client.response.MockRestResponseCreators;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.util.Collections;
+import java.net.UnknownHostException;
 import java.util.List;
+import java.util.function.Function;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 /**
  * @author Pavol Loffay
  */
-public abstract class AbstractTracingClientTest<Template> {
+public abstract class AbstractTracingClientTest {
 
-    protected interface Client<Template> {
+    protected interface Client {
         <T> ResponseEntity<T> getForEntity(String url, Class<T> type);
-        Template template();
     }
 
     protected final MockTracer mockTracer = new MockTracer(new ThreadLocalScopeManager(),
             MockTracer.Propagator.TEXT_MAP);
-    protected MockRestServiceServer mockServer;
-    protected Client<Template> client;
+    protected final Client client;
+    protected final String componentName;
+
+    protected AbstractTracingClientTest(final Function<Tracer, Client> clientFactory, final String componentName) {
+        this.client = clientFactory.apply(mockTracer);
+        this.componentName = componentName;
+    }
+
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(wireMockConfig()
+            .dynamicPort()
+            .extensions(new ResponseTemplateTransformer(true)));
 
     @Before
     public void before() {
         mockTracer.reset();
     }
 
-    @After
-    public void after() {
-        mockServer.verify();
-    }
-
     @Test
     public void testStandardTags() {
-        String url = "http://localhost/foo";
+        final String path = "/foo";
+        final String url = wireMockRule.url(path);
         {
-            mockServer.expect(MockRestRequestMatchers.requestTo(url))
-                    .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-                    .andRespond(MockRestResponseCreators.withSuccess());
-            client.getForEntity(url, String.class);
-        }
-
-        List<MockSpan> mockSpans = mockTracer.finishedSpans();
-        Assert.assertEquals(1, mockSpans.size());
-
-        MockSpan mockSpan = mockSpans.get(0);
-        Assert.assertEquals("GET", mockSpan.operationName());
-        Assert.assertEquals(5, mockSpan.tags().size());
-        Assert.assertEquals(RestTemplateSpanDecorator.StandardTags.COMPONENT_NAME,
-                mockSpan.tags().get(Tags.COMPONENT.getKey()));
-        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
-        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
-        Assert.assertEquals(url, mockSpan.tags().get(Tags.HTTP_URL.getKey()));
-        Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
-        Assert.assertEquals(0, mockSpan.logEntries().size());
-    }
-
-    @Test
-    public void testStandardTagsWithPort() {
-        String url = "http://localhost:4000/foo";
-        {
-            mockServer.expect(MockRestRequestMatchers.requestTo(url))
-                    .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-                    .andRespond(MockRestResponseCreators.withSuccess());
+            stubFor(get(urlPathEqualTo(path))
+                    .willReturn(ok()));
             client.getForEntity(url, String.class);
         }
 
@@ -94,34 +70,48 @@ public abstract class AbstractTracingClientTest<Template> {
         MockSpan mockSpan = mockSpans.get(0);
         Assert.assertEquals("GET", mockSpan.operationName());
         Assert.assertEquals(6, mockSpan.tags().size());
-        Assert.assertEquals(RestTemplateSpanDecorator.StandardTags.COMPONENT_NAME,
-                mockSpan.tags().get(Tags.COMPONENT.getKey()));
+        Assert.assertEquals(componentName, mockSpan.tags().get(Tags.COMPONENT.getKey()));
         Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(url, mockSpan.tags().get(Tags.HTTP_URL.getKey()));
         Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
-        Assert.assertEquals(4000, mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(wireMockRule.port(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
+        Assert.assertEquals(0, mockSpan.logEntries().size());
+    }
+
+    @Test
+    public void testStandardTagsWithPort() {
+        final String path = "/foo";
+        final String url = wireMockRule.url(path);
+        {
+            stubFor(get(urlPathEqualTo(path))
+                    .willReturn(ok()));
+            client.getForEntity(url, String.class);
+        }
+
+        List<MockSpan> mockSpans = mockTracer.finishedSpans();
+        Assert.assertEquals(1, mockSpans.size());
+
+        MockSpan mockSpan = mockSpans.get(0);
+        Assert.assertEquals("GET", mockSpan.operationName());
+        Assert.assertEquals(6, mockSpan.tags().size());
+        Assert.assertEquals(componentName, mockSpan.tags().get(Tags.COMPONENT.getKey()));
+        Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
+        Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
+        Assert.assertEquals(url, mockSpan.tags().get(Tags.HTTP_URL.getKey()));
+        Assert.assertEquals(200, mockSpan.tags().get(Tags.HTTP_STATUS.getKey()));
+        Assert.assertEquals(wireMockRule.port(), mockSpan.tags().get(Tags.PEER_PORT.getKey()));
         Assert.assertEquals(0, mockSpan.logEntries().size());
     }
 
     @Test
     public void testInject() {
-        String url = "http://localhost:4000/foo";
-        mockServer.expect(MockRestRequestMatchers.requestTo(url))
-                .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-                .andRespond(new ResponseCreator() {
-                    @Override
-                    public ClientHttpResponse createResponse(ClientHttpRequest request) throws IOException {
-                        MockClientHttpResponse response =
-                                new MockClientHttpResponse(new byte[1], HttpStatus.OK);
-
-                        response.getHeaders().add("traceId", request.getHeaders()
-                                .getFirst("traceId"));
-                        response.getHeaders().add("spanId", request.getHeaders()
-                                .getFirst("spanId"));
-                        return response;
-                    }
-                });
+        final String path = "/foo";
+        final String url = wireMockRule.url(path);
+        stubFor(get(urlPathEqualTo(path))
+                .willReturn(ok()
+                        .withHeader("traceId", "{{request.headers.traceid}}")
+                        .withHeader("spanId", "{{request.headers.spanid}}")));
 
         ResponseEntity<String> responseEntity = client.getForEntity(url, String.class);
 
@@ -138,10 +128,10 @@ public abstract class AbstractTracingClientTest<Template> {
         {
             Scope parent = mockTracer.buildSpan("parent").startActive(true);
 
-            String url = "http://localhost/foo";
-            mockServer.expect(MockRestRequestMatchers.requestTo(url))
-                    .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
-                    .andRespond(MockRestResponseCreators.withSuccess());
+            final String path = "/foo";
+            final String url = wireMockRule.url(path);
+            stubFor(get(urlPathEqualTo(path))
+                    .willReturn(ok()));
             client.getForEntity(url, String.class);
 
             parent.close();
@@ -157,11 +147,9 @@ public abstract class AbstractTracingClientTest<Template> {
     public void testErrorUnknownHostException() {
         String url = "http://nonexisting.example.com";
         try {
-            RestTemplate restTemplate = new RestTemplate();
-            restTemplate.setInterceptors(Collections.<ClientHttpRequestInterceptor>singletonList(
-                    new TracingRestTemplateInterceptor(mockTracer)));
-            restTemplate.getForEntity(url, String.class);
-        } catch (ResourceAccessException ex) {
+            client.getForEntity(url, String.class);
+        } catch (RuntimeException ex) {
+            Assert.assertTrue(NestedExceptionUtils.getRootCause(ex) instanceof UnknownHostException);
             //ok UnknownHostException
         }
 
@@ -171,8 +159,7 @@ public abstract class AbstractTracingClientTest<Template> {
         MockSpan mockSpan = mockSpans.get(0);
         Assert.assertEquals("GET", mockSpan.operationName());
         Assert.assertEquals(5, mockSpan.tags().size());
-        Assert.assertEquals(RestTemplateSpanDecorator.StandardTags.COMPONENT_NAME,
-                mockSpan.tags().get(Tags.COMPONENT.getKey()));
+        Assert.assertEquals(componentName, mockSpan.tags().get(Tags.COMPONENT.getKey()));
         Assert.assertEquals(Tags.SPAN_KIND_CLIENT, mockSpan.tags().get(Tags.SPAN_KIND.getKey()));
         Assert.assertEquals("GET", mockSpan.tags().get(Tags.HTTP_METHOD.getKey()));
         Assert.assertEquals(url, mockSpan.tags().get(Tags.HTTP_URL.getKey()));

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import io.opentracing.Scope;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingAsyncRestTemplateTest.java
@@ -83,21 +83,15 @@ public class TracingAsyncRestTemplateTest extends AbstractTracingClientTest {
         for (int i = 0; i < numberOfCalls; i++) {
             final String requestUrl = url + i;
 
-            final Scope parentSpan = mockTracer.buildSpan("foo").startActive(false);
-            parentSpan.span().setTag("request-url", requestUrl);
-
-            final Span cont = parentSpan.span();
-
-            futures.add(executorService.submit(new Runnable() {
-                @Override
-                public void run() {
-                    try (Scope span = mockTracer.scopeManager().activate(cont, true)) {
+            try (final Scope parentSpan = mockTracer.buildSpan("foo")
+                    .withTag("request-url", requestUrl)
+                    .startActive(false)) {
+                futures.add(executorService.submit(() -> {
+                    try (final Scope span = mockTracer.scopeManager().activate(parentSpan.span(), true)) {
                         client.getForEntity(requestUrl, String.class);
                     }
-                }
-            }));
-
-            parentSpan.close();
+                }));
+            }
         }
 
         // wait to finish all calls

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateTest.java
@@ -1,8 +1,6 @@
 package io.opentracing.contrib.spring.web.client;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
@@ -10,25 +8,20 @@ import java.util.Collections;
 /**
  * @author Pavol Loffay
  */
-public class TracingRestTemplateTest extends AbstractTracingClientTest<RestTemplate> {
+public class TracingRestTemplateTest extends AbstractTracingClientTest {
 
     public TracingRestTemplateTest() {
-        final RestTemplate restTemplate = new RestTemplate();
-        restTemplate.setInterceptors(Collections.<ClientHttpRequestInterceptor>singletonList(
-                new TracingRestTemplateInterceptor(mockTracer)));
+        super(tracer -> {
+            final RestTemplate restTemplate = new RestTemplate();
+            restTemplate.setInterceptors(Collections.singletonList(
+                    new TracingRestTemplateInterceptor(tracer)));
 
-        client = new Client<RestTemplate>() {
-            @Override
-            public <T> ResponseEntity<T> getForEntity(String url, Class<T> clazz) {
-                return restTemplate.getForEntity(url, clazz);
-            }
-
-            @Override
-            public RestTemplate template() {
-                return restTemplate;
-            }
-        };
-
-        mockServer = MockRestServiceServer.bindTo(client.template()).build();
+            return new Client() {
+                @Override
+                public <T> ResponseEntity<T> getForEntity(String url, Class<T> clazz) {
+                    return restTemplate.getForEntity(url, clazz);
+                }
+            };
+        }, RestTemplateSpanDecorator.StandardTags.COMPONENT_NAME);
     }
 }

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingRestTemplateTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.client;
 
 import org.springframework.http.ResponseEntity;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingWebClientTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/client/TracingWebClientTest.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2016-2018 The OpenTracing Authors
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorJavaConfigIntegrationTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorJavaConfigIntegrationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor;
 
 import io.opentracing.Tracer;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor;
 
 import static org.junit.Assert.assertFalse;

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorXmlConfigIntegrationTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/interceptor/TracingHandlerInterceptorXmlConfigIntegrationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.web.interceptor;
 
 import org.junit.Test;

--- a/opentracing-spring-web/src/test/resources/test-context.xml
+++ b/opentracing-spring-web/src/test/resources/test-context.xml
@@ -1,3 +1,18 @@
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2016-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -26,6 +41,8 @@
     </license>
   </licenses>
 
+  <inceptionYear>2016</inceptionYear>
+
   <developers>
     <developer>
       <id>pavolloffay</id>
@@ -38,6 +55,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <main.basedir>${project.basedir}</main.basedir>
 
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
     <version.io.opentracing>0.31.0</version.io.opentracing>
@@ -54,6 +72,7 @@
 
     <!-- plugins -->
     <version.maven-deploy-plugin>2.8.2</version.maven-deploy-plugin>
+    <version.maven-license-plugin>3.0</version.maven-license-plugin>
     <version.maven-jar-plugin>3.0.2</version.maven-jar-plugin>
     <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
     <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
@@ -148,6 +167,11 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${version.maven-license-plugin}</version>
+        </plugin>
         <!-- mvn -N io.takari:maven:wrapper -Dmaven=3.5.0 -->
         <plugin>
           <groupId>io.takari</groupId>
@@ -177,6 +201,46 @@
           <repo>maven</repo>
           <packageName>opentracing-spring-web</packageName>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>${version.maven-license-plugin}</version>
+        <configuration>
+          <header>${main.basedir}/header.txt</header>
+          <failIfMissing>true</failIfMissing>
+          <failIfUnknown>true</failIfUnknown>
+          <excludes>
+            <exclude>LICENSE</exclude>
+            <exclude>mvnw</exclude>
+            <exclude>mvnw.cmd</exclude>
+            <exclude>travis/publish.sh</exclude>
+            <exclude>.mvn/wrapper/maven-wrapper.properties</exclude>
+            <exclude>**/*.factories</exclude>
+            <exclude>**/TracingClientResponseMono.java</exclude>
+            <exclude>**/TracingClientResponseSubscriber.java</exclude>
+            <exclude>**/TracingExchangeFilterFunction.java</exclude>
+            <exclude>**/TracingWebClientBeanPostProcessor.java</exclude>
+            <exclude>**/TracingOperator.java</exclude>
+            <exclude>**/TracingSubscriber.java</exclude>
+            <exclude>**/TracingWebFilter.java</exclude>
+          </excludes>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin-git</artifactId>
+            <version>${version.maven-license-plugin}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
   </developers>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
@@ -49,6 +49,8 @@
     <version.org.springframework.boot>2.1.1.RELEASE</version.org.springframework.boot>
     <!-- Should match version from https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-dependencies/pom.xml  -->
     <version.org.springframework>5.1.3.RELEASE</version.org.springframework>
+    <version.com.github.tomakehurst-wiremock-jre8>2.21.0</version.com.github.tomakehurst-wiremock-jre8>
+    <version.io.projectreactor.netty-reactor-netty>0.8.5.RELEASE</version.io.projectreactor.netty-reactor-netty>
 
     <!-- plugins -->
     <version.maven-deploy-plugin>2.8.2</version.maven-deploy-plugin>


### PR DESCRIPTION
This adds Spring WebFlux and WebClient tracing.

I will also add auto-configuration for https://github.com/opentracing-contrib/java-reactor to `opentracing-spring-cloud`, which will complement these changes with automatic activation of the span in handler functions.