### PR TITLE
WebFlux tracing should trace all URLs by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ class TracingConfiguration {
                 tracer,
                 Integer.MIN_VALUE,               // Order
                 Pattern.compile(""),             // Skip pattern
-                Collections.singletonList("/*"), // URL patterns
+                Collections.emptyList(),         // URL patterns, empty list means all
                 Arrays.asList(new WebFluxSpanDecorator.StandardTags(), new WebFluxSpanDecorator.WebFluxTags())
         );
     }

--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
@@ -33,7 +33,18 @@ public class WebTracingProperties {
     private boolean enabled = true;
     private Pattern skipPattern = DEFAULT_SKIP_PATTERN;
     private int order = Integer.MIN_VALUE;
-    private List<String> urlPatterns = new ArrayList<>(Collections.singletonList("/*"));
+
+    /**
+     * List of URL patterns that should be traced.
+     *
+     * For servlet web stack, the URL pattern syntax is defined in the Servlet spec, under "Specification of Mappings".
+     * For reactive (WebFlux), see the documentation of {@link org.springframework.web.util.pattern.PathPattern} for
+     * the syntax.
+     *
+     * By default, the list is empty, which means that all requests will be traced (unless {@link #skipPattern} says
+     * otherwise.)
+     */
+    private List<String> urlPatterns = Collections.emptyList();
 
     public boolean isEnabled() {
         return enabled;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
@@ -40,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Pavol Loffay
+ *
+ * Test that the default settings in {@link WebTracingProperties} work as expected.
  */
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -86,6 +88,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
     @Qualifier("mockDecorator2")
     private ServletFilterSpanDecorator mockDecorator2;
 
+    // Test that top level paths are traced by default
     @Test
     public void testRequestIsTraced() {
         testRestTemplate.getForEntity("/hello", String.class);
@@ -93,6 +96,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
         assertThat(mockTracer.finishedSpans()).hasSize(1);
     }
 
+    // Test that lower level paths are traced by default as well
     @Test
     public void testNestedRequestIsTraced() {
         testRestTemplate.getForEntity("/hello/nested", String.class);
@@ -100,6 +104,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
         assertThat(mockTracer.finishedSpans()).hasSize(1);
     }
 
+    // Test that /info is excluded due to the default skipPattern
     @Test
     public void testExcluded() throws InterruptedException {
         testRestTemplate.getForEntity("/info", String.class);

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.contrib.web.servlet.filter.ServletFilterSpanDecorator;
+import io.opentracing.mock.MockTracer;
+import org.awaitility.Awaitility;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Pavol Loffay
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {ServerTracingAutoConfigurationDefaultsTest.SpringConfiguration.class},
+        properties = "opentracing.spring.web.client.enabled=false")
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfigurationBaseTest  {
+
+    private static CountDownLatch infoCountDownLatch = new CountDownLatch(1);
+
+    @RestController
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer();
+        }
+
+        @RequestMapping("/hello")
+        public void hello() {
+        }
+
+        @RequestMapping("/hello/nested")
+        public void nestedHello() {
+        }
+
+        @RequestMapping("/info")
+        public void info() {
+            infoCountDownLatch.countDown();
+        }
+    }
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @MockBean
+    @Qualifier("mockDecorator1")
+    private ServletFilterSpanDecorator mockDecorator1;
+    @MockBean
+    @Qualifier("mockDecorator2")
+    private ServletFilterSpanDecorator mockDecorator2;
+
+    @Test
+    public void testRequestIsTraced() {
+        testRestTemplate.getForEntity("/hello", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+    }
+
+    @Test
+    public void testNestedRequestIsTraced() {
+        testRestTemplate.getForEntity("/hello/nested", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+    }
+
+    @Test
+    public void testExcluded() throws InterruptedException {
+        testRestTemplate.getForEntity("/info", String.class);
+        infoCountDownLatch.await();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(0);
+    }
+
+    public Callable<Integer> reportedSpansSize() {
+        return () -> mockTracer.finishedSpans().size();
+    }
+
+    @After()
+    public void reset() {
+        mockTracer.reset();
+        infoCountDownLatch = new CountDownLatch(1);
+    }
+}

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDefaultsTest.java
@@ -40,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Csaba Kos
+ *
+ * Test that the default settings in {@link WebTracingProperties} work as expected.
  */
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -86,6 +88,7 @@ public class WebFluxTracingAutoConfigurationDefaultsTest extends AutoConfigurati
     @Qualifier("mockDecorator2")
     private WebFluxSpanDecorator mockDecorator2;
 
+    // Test that top level paths are traced by default
     @Test
     public void testRequestIsTraced() {
         testRestTemplate.getForEntity("/hello", String.class);
@@ -93,6 +96,7 @@ public class WebFluxTracingAutoConfigurationDefaultsTest extends AutoConfigurati
         assertThat(mockTracer.finishedSpans()).hasSize(1);
     }
 
+    // Test that lower level paths are traced by default as well
     @Test
     public void testNestedRequestIsTraced() {
         testRestTemplate.getForEntity("/hello/nested", String.class);
@@ -100,6 +104,7 @@ public class WebFluxTracingAutoConfigurationDefaultsTest extends AutoConfigurati
         assertThat(mockTracer.finishedSpans()).hasSize(1);
     }
 
+    // Test that /info is excluded due to the default skipPattern
     @Test
     public void testExcluded() throws InterruptedException {
         testRestTemplate.getForEntity("/info", String.class);

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationDefaultsTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2016-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.contrib.spring.web.webfilter.WebFluxSpanDecorator;
+import io.opentracing.mock.MockTracer;
+import org.awaitility.Awaitility;
+import org.hamcrest.core.IsEqual;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Csaba Kos
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {WebFluxTracingAutoConfigurationDefaultsTest.SpringConfiguration.class},
+        properties = {"opentracing.spring.web.client.enabled=false", "spring.main.web-application-type=reactive"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class WebFluxTracingAutoConfigurationDefaultsTest extends AutoConfigurationBaseTest  {
+
+    private static CountDownLatch infoCountDownLatch = new CountDownLatch(1);
+
+    @RestController
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer();
+        }
+
+        @RequestMapping("/hello")
+        public void hello() {
+        }
+
+        @RequestMapping("/hello/nested")
+        public void nestedHello() {
+        }
+
+        @RequestMapping("/info")
+        public void info() {
+            infoCountDownLatch.countDown();
+        }
+    }
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @MockBean
+    @Qualifier("mockDecorator1")
+    private WebFluxSpanDecorator mockDecorator1;
+    @MockBean
+    @Qualifier("mockDecorator2")
+    private WebFluxSpanDecorator mockDecorator2;
+
+    @Test
+    public void testRequestIsTraced() {
+        testRestTemplate.getForEntity("/hello", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+    }
+
+    @Test
+    public void testNestedRequestIsTraced() {
+        testRestTemplate.getForEntity("/hello/nested", String.class);
+        Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
+        assertThat(mockTracer.finishedSpans()).hasSize(1);
+    }
+
+    @Test
+    public void testExcluded() throws InterruptedException {
+        testRestTemplate.getForEntity("/info", String.class);
+        infoCountDownLatch.await();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(0);
+    }
+
+    public Callable<Integer> reportedSpansSize() {
+        return () -> mockTracer.finishedSpans().size();
+    }
+
+    @After()
+    public void reset() {
+        mockTracer.reset();
+        infoCountDownLatch = new CountDownLatch(1);
+    }
+}

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/TracingWebFilter.java
@@ -111,7 +111,7 @@ public class TracingWebFilter implements WebFilter, Ordered {
                 return false;
             }
         }
-        if (urlPatterns.stream().noneMatch(urlPattern -> urlPattern.matches(pathWithinApplication))) {
+        if (!urlPatterns.isEmpty() && urlPatterns.stream().noneMatch(urlPattern -> urlPattern.matches(pathWithinApplication))) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Not tracing request " + request + " because it does not match any URL pattern: " + urlPatterns);
             }


### PR DESCRIPTION
The `urlPatterns` field in `WebTracingProperties` has different semantics for servlet and reactive web server technologies. (This naturally comes from the fact that the semantics are defined in the servlet spec for the former, and by the implementation in WebFlux for the latter.)

The default value of `urlPatterns` is set to `/*`, which enables tracing of all URLs in case of servlet stack, but it means "only single path component URLs" for reactive/WebFlux (e.g. `/foo` would be traced but not `/foo/bar`).

This PR ensures that by default all URLs will be traced by both servlet and reactive stacks, and it also improves on the documentation of the `urlPatterns` field to make the difference in semantics clear.