### PR TITLE
Actuator endpoint skipped by default

### DIFF
--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/WebTracingProperties.java
@@ -27,7 +27,7 @@ public class WebTracingProperties {
     public static final String CONFIGURATION_PREFIX = "opentracing.spring.web";
 
     public static final Pattern DEFAULT_SKIP_PATTERN = Pattern.compile(
-            "/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|" +
+            "/api-docs.*|/autoconfig|/configprops|/dump|/health|/info|/metrics.*|/actuator.*|" +
             "/mappings|/swagger.*|.*\\.png|.*\\.css|.*\\.js|.*\\.html|/favicon.ico|/hystrix.stream");
 
     private boolean enabled = true;

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
@@ -52,6 +52,8 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
 
     private static CountDownLatch infoCountDownLatch = new CountDownLatch(1);
 
+    private static CountDownLatch actuatorInfoCountDownLatch = new CountDownLatch(1);
+
     @RestController
     @Configuration
     @EnableAutoConfiguration
@@ -76,7 +78,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
 
         @RequestMapping("/actuator/info")
         public void actuatorInfo() {
-            infoCountDownLatch.countDown();
+            actuatorInfoCountDownLatch.countDown();
         }
     }
 
@@ -124,7 +126,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
     @Test
     public void testActuatorExcluded() throws InterruptedException {
         testRestTemplate.getForEntity("/actuator/info", String.class);
-        infoCountDownLatch.await();
+        actuatorInfoCountDownLatch.await();
 
         assertThat(mockTracer.finishedSpans()).hasSize(0);
         assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
@@ -113,7 +113,7 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
 
     // Test that /info is excluded due to the default skipPattern
     @Test
-    public void testExcluded() throws InterruptedException {
+    public void testInfoExcluded() throws InterruptedException {
         testRestTemplate.getForEntity("/info", String.class);
         infoCountDownLatch.await();
 

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/ServerTracingAutoConfigurationDefaultsTest.java
@@ -73,6 +73,11 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
         public void info() {
             infoCountDownLatch.countDown();
         }
+
+        @RequestMapping("/actuator/info")
+        public void actuatorInfo() {
+            infoCountDownLatch.countDown();
+        }
     }
 
     @Autowired
@@ -108,6 +113,17 @@ public class ServerTracingAutoConfigurationDefaultsTest extends AutoConfiguratio
     @Test
     public void testExcluded() throws InterruptedException {
         testRestTemplate.getForEntity("/info", String.class);
+        infoCountDownLatch.await();
+
+        assertThat(mockTracer.finishedSpans()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(0);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(0);
+    }
+
+    // Test that /actuator/info is excluded due to the default skipPattern
+    @Test
+    public void testActuatorExcluded() throws InterruptedException {
+        testRestTemplate.getForEntity("/actuator/info", String.class);
         infoCountDownLatch.await();
 
         assertThat(mockTracer.finishedSpans()).hasSize(0);


### PR DESCRIPTION
I've fixed it https://github.com/opentracing-contrib/java-spring-web/issues/98, is it ok?

