### PR TITLE
Include general enable property for RestTemplateTracingAutoConfiguration

### DIFF
--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The OpenTracing Authors
+ * Copyright 2016-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -53,7 +53,7 @@ import java.util.Set;
 @Configuration
 @ConditionalOnBean(Tracer.class)
 @ConditionalOnClass(RestTemplate.class)
-@ConditionalOnProperty(prefix = WebClientTracingProperties.CONFIGURATION_PREFIX, name = "enabled", matchIfMissing = true)
+@ConditionalOnProperty(prefix = WebTracingProperties.CONFIGURATION_PREFIX, name = {"enabled", "client.enabled"}, matchIfMissing = true)
 @AutoConfigureAfter(TracerAutoConfiguration.class)
 @EnableConfigurationProperties(WebClientTracingProperties.class)
 public class RestTemplateTracingAutoConfiguration {

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfigurationDisabledWebTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/RestTemplateTracingAutoConfigurationDisabledWebTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2016-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.web.starter;
+
+import io.opentracing.contrib.spring.web.client.TracingRestTemplateInterceptor;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.awaitility.Awaitility;
+import org.hamcrest.core.IsEqual;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.web.client.AsyncRestTemplate;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = {RestTemplateTracingAutoConfigurationDisabledWebTest.SpringConfiguration.class},
+        properties = {"opentracing.spring.web.enabled=false"})
+@RunWith(SpringJUnit4ClassRunner.class)
+@ActiveProfiles("test")
+public class RestTemplateTracingAutoConfigurationDisabledWebTest extends AutoConfigurationBaseTest {
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+
+        @Bean
+        public MockTracer tracer() {
+            return new MockTracer(new ThreadLocalScopeManager());
+        }
+
+        @Bean
+        public RestTemplate restTemplate() {
+            return new RestTemplate();
+        }
+
+        @Bean
+        public AsyncRestTemplate asyncRestTemplate() {
+            return new AsyncRestTemplate();
+        }
+    }
+
+    @Autowired
+    private MockTracer mockTracer;
+    @Autowired
+    private RestTemplate restTemplate;
+    @Autowired
+    private AsyncRestTemplate asyncRestTemplate;
+
+    @Before
+    public void setUp() {
+        mockTracer.reset();
+    }
+
+    @Test
+    public void testInterceptorNotRegistered() {
+        for (ClientHttpRequestInterceptor interceptor : restTemplate.getInterceptors()) {
+            assertThat(interceptor).isNotInstanceOf(TracingRestTemplateInterceptor.class);
+        }
+    }
+
+    @Test
+    public void testAsyncInterceptorNotRegistered() {
+        for (AsyncClientHttpRequestInterceptor interceptor : asyncRestTemplate.getInterceptors()) {
+            assertThat(interceptor).isNotInstanceOf(TracingRestTemplateInterceptor.class);
+        }
+    }
+
+    @Test
+    public void testRestClientNotTracing() {
+        try {
+            restTemplate.getForEntity("http://nonexisting.example.com", String.class);
+        } catch (ResourceAccessException ex) {
+            //ok UnknownHostException
+        }
+        Assert.assertEquals(0, mockTracer.finishedSpans().size());
+    }
+
+    @Test
+    public void testAsyncRestClientNotTracing() {
+        ListenableFuture<ResponseEntity<String>> future = asyncRestTemplate.getForEntity("http://nonexisting.example.com", String.class);
+
+        AtomicBoolean done = AsyncRestTemplatePostProcessingConfigurationTest.addDoneCallback(future);
+        Awaitility.await().atMost(500, TimeUnit.MILLISECONDS).untilAtomic(done, IsEqual.equalTo(true));
+
+        Assert.assertEquals(0, mockTracer.finishedSpans().size());
+    }
+}


### PR DESCRIPTION
I would expect, if you set the property `opentracing.spring.web.enabled` to false, that everything belonging to it will be disabled as well.
The RestTemplateTracingAutoConfiguration currently just listens to the property `opentracing.spring.web.client.enabled`, which is a sub property of the other one.
Therefore I suggest to include the basic property in the Conditional and just enable this configuration if both are enabled or missing (opt-out)