### PR TITLE
fix(deps): Update spring-tracer-configuration-starter to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-web-servlet-filter>0.4.0</version.io.opentracing.contrib-opentracing-web-servlet-filter>
     <version.io.opentracing.contrib-opentracing-tracerresolver>0.1.8</version.io.opentracing.contrib-opentracing-tracerresolver>
-    <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.3.1</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
+    <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.4.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
     <version.junit>4.13.1</version.junit>
     <version.org.mockito-mockito-core>2.23.4</version.org.mockito-mockito-core>
     <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
@@ -148,13 +148,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>${version.org.mockito-mockito-core}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Bumps the dependency indicated for upstream consistency (see https://github.com/opentracing-contrib/java-spring-jaeger/issues/112 for one of the effects).

Also removes a pair of redundant version declarations.