### PR TITLE
Add onCreate callback to WebFluxSpanDecorator

### DIFF
--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/WebFluxTracingAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The OpenTracing Authors
+ * Copyright 2016-2021 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -126,8 +126,8 @@ public class WebFluxTracingAutoConfigurationTest extends AutoConfigurationBaseTe
         Awaitility.await().until(reportedSpansSize(), IsEqual.equalTo(1));
 
         assertThat(mockTracer.finishedSpans()).hasSize(1);
-        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(2);
-        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(2);
+        assertThat(Mockito.mockingDetails(mockDecorator1).getInvocations()).hasSize(3);
+        assertThat(Mockito.mockingDetails(mockDecorator2).getInvocations()).hasSize(3);
     }
 
     @Test

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The OpenTracing Authors
+ * Copyright 2016-2021 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -34,8 +34,17 @@ import java.util.concurrent.TimeoutException;
 public interface WebFluxSpanDecorator {
 
     /**
-     * Decorate span before {@code .onSubscribe()} is called. This is called right after span in created. Span
-     * context is already present in request attributes with name {@link TracingWebFilter#SERVER_SPAN_CONTEXT}.
+     * Decorate span right after its creation.
+     * Span context is already present in request attributes with name {@link TracingWebFilter#SERVER_SPAN_CONTEXT}.
+     *
+     * @param exchange web exchange
+     * @param span span to decorate
+     */
+    void onCreate(ServerWebExchange exchange, Span span);
+
+    /**
+     * Decorate span when {@code .onSubscribe()} is called.
+     * Span context is already present in request attributes with name {@link TracingWebFilter#SERVER_SPAN_CONTEXT}.
      *
      * @param exchange web exchange
      * @param span span to decorate
@@ -66,6 +75,11 @@ public interface WebFluxSpanDecorator {
      */
     class StandardTags implements WebFluxSpanDecorator {
         static final String COMPONENT_NAME = "java-spring-webflux";
+
+        @Override
+        public void onCreate(ServerWebExchange exchange, Span span) {
+            // No-op
+        }
 
         @Override
         public void onRequest(final ServerWebExchange exchange, final Span span) {
@@ -112,6 +126,12 @@ public interface WebFluxSpanDecorator {
      * Adds tags from WebFlux handler to span.
      */
     class WebFluxTags implements WebFluxSpanDecorator {
+
+        @Override
+        public void onCreate(ServerWebExchange exchange, Span span) {
+            // No-op
+        }
+
         @Override
         public void onRequest(final ServerWebExchange exchange, final Span span) {
             // No-op

--- a/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
+++ b/opentracing-spring-web/src/main/java/io/opentracing/contrib/spring/web/webfilter/WebFluxSpanDecorator.java
@@ -40,7 +40,7 @@ public interface WebFluxSpanDecorator {
      * @param exchange web exchange
      * @param span span to decorate
      */
-    void onCreate(ServerWebExchange exchange, Span span);
+    default void onCreate(ServerWebExchange exchange, Span span) { }
 
     /**
      * Decorate span when {@code .onSubscribe()} is called.
@@ -75,11 +75,6 @@ public interface WebFluxSpanDecorator {
      */
     class StandardTags implements WebFluxSpanDecorator {
         static final String COMPONENT_NAME = "java-spring-webflux";
-
-        @Override
-        public void onCreate(ServerWebExchange exchange, Span span) {
-            // No-op
-        }
 
         @Override
         public void onRequest(final ServerWebExchange exchange, final Span span) {
@@ -126,12 +121,6 @@ public interface WebFluxSpanDecorator {
      * Adds tags from WebFlux handler to span.
      */
     class WebFluxTags implements WebFluxSpanDecorator {
-
-        @Override
-        public void onCreate(ServerWebExchange exchange, Span span) {
-            // No-op
-        }
-
         @Override
         public void onRequest(final ServerWebExchange exchange, final Span span) {
             // No-op

--- a/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriberTest.java
+++ b/opentracing-spring-web/src/test/java/io/opentracing/contrib/spring/web/webfilter/TracingSubscriberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2020 The OpenTracing Authors
+ * Copyright 2016-2021 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import io.opentracing.util.ThreadLocalScopeManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpMethod;
@@ -38,8 +39,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TracingSubscriberTest {
@@ -91,9 +92,12 @@ public class TracingSubscriberTest {
         assertEquals(SignalType.ON_COMPLETE, finalSignalType.get());
 
         Span finishedSpan = tracer.finishedSpans().get(0);
-        verify(spanDecorator).onRequest(exchange, finishedSpan);
-        verify(spanDecorator).onResponse(exchange, finishedSpan);
-        verify(spanDecorator, never()).onError(any(ServerWebExchange.class), any(Throwable.class), any(Span.class));
+
+        InOrder inOrder = inOrder(spanDecorator);
+        inOrder.verify(spanDecorator).onCreate(exchange, finishedSpan);
+        inOrder.verify(spanDecorator).onRequest(exchange, finishedSpan);
+        inOrder.verify(spanDecorator).onResponse(exchange, finishedSpan);
+        verifyNoMoreInteractions(spanDecorator);
     }
 
     @Test
@@ -122,9 +126,12 @@ public class TracingSubscriberTest {
         assertEquals(SignalType.ON_ERROR, finalSignalType.get());
 
         Span finishedSpan = tracer.finishedSpans().get(0);
-        verify(spanDecorator).onRequest(exchange, finishedSpan);
-        verify(spanDecorator).onError(eq(exchange), any(Throwable.class), eq(finishedSpan));
-        verify(spanDecorator, never()).onResponse(any(ServerWebExchange.class), any(Span.class));
+
+        InOrder inOrder = inOrder(spanDecorator);
+        inOrder.verify(spanDecorator).onCreate(exchange, finishedSpan);
+        inOrder.verify(spanDecorator).onRequest(exchange, finishedSpan);
+        inOrder.verify(spanDecorator).onError(eq(exchange), any(Throwable.class), eq(finishedSpan));
+        verifyNoMoreInteractions(spanDecorator);
     }
 
     @Test
@@ -168,8 +175,10 @@ public class TracingSubscriberTest {
         assertEquals(SignalType.CANCEL, finalSignalType.get());
 
         Span finishedSpan = tracer.finishedSpans().get(0);
-        verify(spanDecorator).onRequest(exchange, finishedSpan);
-        verify(spanDecorator, never()).onError(any(ServerWebExchange.class), any(Throwable.class), any(Span.class));
-        verify(spanDecorator, never()).onResponse(any(ServerWebExchange.class), any(Span.class));
+
+        InOrder inOrder = inOrder(spanDecorator);
+        inOrder.verify(spanDecorator).onCreate(exchange, finishedSpan);
+        inOrder.verify(spanDecorator).onRequest(exchange, finishedSpan);
+        verifyNoMoreInteractions(spanDecorator);
     }
 }


### PR DESCRIPTION
Hello!

With this PR, `WebFluxSpanDecorator` will be extended with an `onCreate()` callback called right after the span creation.
Cf this issue: #140

Thanks, @geoand.