### PR TITLE
fix #147 by using the base path attribute instead for 2.6 compatibility.

### DIFF
--- a/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/SkipPatternAutoConfiguration.java
+++ b/opentracing-spring-web-starter/src/main/java/io/opentracing/contrib/spring/web/starter/SkipPatternAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The OpenTracing Authors
+ * Copyright 2016-2021 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -65,11 +65,15 @@ public class SkipPatternAutoConfiguration {
 
     static Optional<Pattern> getPatternForManagementServerProperties(
         ManagementServerProperties managementServerProperties) {
-      String contextPath = managementServerProperties.getServlet().getContextPath();
+      String contextPath = managementServerProperties.getBasePath();
       if (StringUtils.hasText(contextPath)) {
-        return Optional.of(Pattern.compile(contextPath + ".*"));
+        return Optional.of(Pattern.compile(cleanup(contextPath) + ".*"));
       }
       return Optional.empty();
+    }
+
+    private static String cleanup(String contextPath) {
+      return contextPath.startsWith("/") ? contextPath.substring(1) : contextPath;
     }
 
     @Bean

--- a/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/SkipPatternConfigTest.java
+++ b/opentracing-spring-web-starter/src/test/java/io/opentracing/contrib/spring/web/starter/SkipPatternConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016-2019 The OpenTracing Authors
+ * Copyright 2016-2021 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -63,9 +63,20 @@ public class SkipPatternConfigTest {
   }
 
   @Test
+  public void testShouldReturnEmptyWhenManagementContextHasOnlyARootSlashHasContextPath() {
+    ManagementServerProperties properties = new ManagementServerProperties();
+    properties.setBasePath("/");
+
+    Optional<Pattern> pattern = new SkipPatternAutoConfiguration.ManagementSkipPatternProviderConfig()
+        .skipPatternForManagementServerProperties(properties).pattern();
+
+    then(pattern).isEmpty();
+  }
+
+  @Test
   public void testShouldReturnManagementContextWithContextPath() {
     ManagementServerProperties properties = new ManagementServerProperties();
-    properties.getServlet().setContextPath("foo");
+    properties.setBasePath("foo");
 
     Optional<Pattern> pattern = new SkipPatternAutoConfiguration.ManagementSkipPatternProviderConfig()
         .skipPatternForManagementServerProperties(properties).pattern();

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2016-2020 The OpenTracing Authors
+    Copyright 2016-2021 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -64,9 +64,9 @@
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.4.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
     <version.junit>4.13.1</version.junit>
     <version.org.mockito-mockito-core>2.23.4</version.org.mockito-mockito-core>
-    <version.org.springframework.boot>2.3.4.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>2.4.0</version.org.springframework.boot>
     <!-- Should match version from https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-dependencies/pom.xml  -->
-    <version.org.springframework>5.2.9.RELEASE</version.org.springframework>
+    <version.org.springframework>5.3.1</version.org.springframework>
     <version.com.github.tomakehurst-wiremock-jre8>2.21.0</version.com.github.tomakehurst-wiremock-jre8>
     <version.io.projectreactor.netty-reactor-netty>0.9.12.RELEASE</version.io.projectreactor.netty-reactor-netty>
 


### PR DESCRIPTION
This PR fixes issue #147. The minimum version of compatible spring-boot version has been upgraded to 2.4.0 which contains the new basePath attribute used in 2.6.0.